### PR TITLE
Allow user to specify a per engine cmd in SSHEngineSetLauncher

### DIFF
--- a/docs/source/process.rst
+++ b/docs/source/process.rst
@@ -424,12 +424,18 @@ on that host.
     c.SSHEngineSetLauncher.engines = { 'host1.example.com' : 2,
                 'host2.example.com' : 5,
                 'host3.example.com' : (1, ['--profile-dir=/home/different/location']),
-                'host4.example.com' : 8 }
+                'host4.example.com' : {'n': 3, 'engine_args': ['--profile-dir=/away/location'], 'engine_cmd': '/home/venv/bin/python'},
+                'host5.example.com' : 8 }
 
 * The `engines` dict, where the keys are the host we want to run engines on and
   the value is the number of engines to run on that host.
 * on host3, the value is a tuple, where the number of engines is first, and the arguments
   to be passed to :command:`ipengine` are the second element.
+* on host4, a dictionary configures the engine. The dictionary can be used to specify 
+  the number of engines to be run on that host `n`, the engine arguments `engine_args`, 
+  as well as the engine command itself `engine_cmd`. This is particularly useful for 
+  virtual environments on heterogeneous clusters where the location of the python 
+  executable might vary from host to host.
 
 For engines without explicitly specified arguments, the default arguments are set in
 a single location:

--- a/ipyparallel/apps/launcher.py
+++ b/ipyparallel/apps/launcher.py
@@ -750,10 +750,16 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
 
         dlist = []
         for host, n in iteritems(self.engines):
+            cmd = None
             if isinstance(n, (tuple, list)):
-                n, args = n
+                if len(n) == 2:
+                    n, args = n
+                elif len(n) == 3:
+                    n, args, cmd = n
             else:
                 args = copy.deepcopy(self.engine_args)
+            if cmd is None:
+                cmd = copy.deepcopy(self.engine_cmd)
 
             if '@' in host:
                 user,host = host.split('@',1)
@@ -770,7 +776,7 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
                     el.to_send = []
 
                 # Copy the engine args over to each engine launcher.
-                el.engine_cmd = self.engine_cmd
+                el.engine_cmd = cmd
                 el.engine_args = args
                 el.on_stop(self._notice_engine_stopped)
                 d = el.start(user=user, hostname=host)

--- a/ipyparallel/apps/launcher.py
+++ b/ipyparallel/apps/launcher.py
@@ -751,12 +751,19 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
         dlist = []
         for host, n in iteritems(self.engines):
             cmd = None
+            args = None
             if isinstance(n, (tuple, list)):
-                if len(n) == 2:
-                    n, args = n
-                elif len(n) == 3:
-                    n, args, cmd = n
-            else:
+                n, args = n
+            if isinstance(n, dict):
+                cdict = n
+                if 'n' not in cdict:
+                    raise ValueError("Need to specify 'n' in engine's config dictionary.")
+                n = cdict['n']
+                if 'engine_args' in cdict:
+                    args = cdict['engine_args']
+                if 'engine_cmd' in cdict:
+                    cmd = cdict['engine_cmd']
+            if args is None:
                 args = copy.deepcopy(self.engine_args)
             if cmd is None:
                 cmd = copy.deepcopy(self.engine_cmd)


### PR DESCRIPTION
I ran into this issue when trying to start engines in a heterogeneous environment where the engine cmd varies. In my specific case, I have some machines running linux and others running macosx. I have my python installation in a virtualenv and would like to call python in that directory. I could't get it working otherwise. The proposed solution allows the user to specify the number of engines per host, the engine arguments and now the engine command. For example:

    c.SSHEngineSetLauncher.engines = {                                                                                                 
        'node1.utoronto.ca': (20,'','/Users/rein/venv/bin/python') ,                                                                                          
        'node2.utoronto.ca': (24,'','/home/rein/venv/bin/python')  
    }

This shouldn't break any previous config files. If you think this is appropriate, then one probably should also change the documentation. 

Another potentially better solution would be to use a dictionary instead of a tuple such as in

    c.SSHEngineSetLauncher.engines = {                                                                                                 
        'node1.utoronto.ca': {'n':20, 'engine_cmd':'/Users/rein/venv/bin/python'} ,                                                                                          
        'node2.utoronto.ca': {'n':24, 'engine_cmd':'/home/rein/venv/bin/python'}
    }

Any opinion?