### PR TITLE
fix installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ ipyparallel is the new home of IPython.parallel.
 To install the `Clusters` tab in Jupyter Notebook, add this to your `jupyter_notebook_config.py`:
 
 ```python
-c.NotebookApp.jupyter_server_extensions.append('ipyparallel.nbextension')
+c.NotebookApp.server_extensions.append('ipyparallel.nbextension')
 ```
 

--- a/ipyparallel/nbextension/static/clusterlist.js
+++ b/ipyparallel/nbextension/static/clusterlist.js
@@ -182,10 +182,6 @@ define([
         });
     };
 
-    // For backwards compatability.
-    IPython.ClusterList = ClusterList;
-    IPython.ClusterItem = ClusterItem;
-
     return {
         'ClusterList': ClusterList,
         'ClusterItem': ClusterItem,


### PR DESCRIPTION
- README note was wrong
- stop attaching names to IPython, which is no longer allowed

closes #15