### PR TITLE
Update the doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install the `IPython Clusters` tab in Jupyter Notebook, add this to your `jup
 c.NotebookApp.server_extensions.append('ipyparallel.nbextension')
 ```
 
-See the [documentation on configuring the notebook server](https://jupyter-notebook.readthedocs.org/en/latest/examples/Notebook/Configuring%20the%20Notebook%20and%20Server.html)
+See the [documentation on configuring the notebook server](https://jupyter-notebook.readthedocs.org/en/latest/public_server.html)
 to find your config or setup your initial `jupyter_notebook_config.py`.
 
 ## Run


### PR DESCRIPTION
Updating the link to the Jupyter Notebook public server doc. Current link leads to not found after [Jupyter notebook PR merge](https://github.com/jupyter/notebook/pull/458)