### PR TITLE
Grab number of engines from inside the config dict.

### DIFF
--- a/ipyparallel/apps/launcher.py
+++ b/ipyparallel/apps/launcher.py
@@ -740,6 +740,8 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
         for n in itervalues(self.engines):
             if isinstance(n, (tuple,list)):
                 n,args = n
+            if isinstance(n, dict):
+                n = n['n']
             count += n
         return count
     


### PR DESCRIPTION
Resolves #45: SSH Engine dict configuration not fully supported