### PR TITLE
Fix issue 56: `UserWarning: get_default_value is deprecated`

### DIFF
--- a/ipyparallel/apps/ipcontrollerapp.py
+++ b/ipyparallel/apps/ipcontrollerapp.py
@@ -403,7 +403,7 @@ class IPControllerApp(BaseParallelApplication):
         if 'TaskScheduler.scheme_name' in self.config:
             scheme = self.config.TaskScheduler.scheme_name
         else:
-            scheme = TaskScheduler.scheme_name.get_default_value()
+            scheme = TaskScheduler.scheme_name.default_value
         # Task Queue (in a Process)
         if scheme == 'pure':
             self.log.warn("task::using pure DEALER Task scheduler")

--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -258,7 +258,7 @@ class HubFactory(RegistrationFactory):
             scheme = self.config.TaskScheduler.scheme_name
         else:
             from .scheduler import TaskScheduler
-            scheme = TaskScheduler.scheme_name.get_default_value()
+            scheme = TaskScheduler.scheme_name.default_value
         
         # build connection dicts
         engine = self.engine_info = {


### PR DESCRIPTION
Fix https://github.com/ipython/ipyparallel/issues/56

Switches over to using `default_value` as recommended.

Given that this class is included internally, there is no need to worry about a case where `get_default_value` would be the only option.