### PR TITLE
run all Client IO in a background thread

### DIFF
--- a/ipyparallel/tests/__init__.py
+++ b/ipyparallel/tests/__init__.py
@@ -105,7 +105,6 @@ def add_engines(n=1, profile='iptest', total=False):
         elif time.time()-tic > 15:
             raise RuntimeError("Timeout waiting for engines to connect.")
         time.sleep(.1)
-        rc.spin()
     rc.close()
     return eps
 

--- a/ipyparallel/tests/clienttest.py
+++ b/ipyparallel/tests/clienttest.py
@@ -161,7 +161,6 @@ class ClusterTestCase(BaseZMQTestCase):
             if f():
                 return
             time.sleep(0.1)
-            self.client.spin()
         if not f():
             print("Warning: Awaited condition never arrived")
     
@@ -182,7 +181,6 @@ class ClusterTestCase(BaseZMQTestCase):
         # allow flushing of incoming messages to prevent crash on socket close
         self.client.wait(timeout=2)
         # time.sleep(2)
-        self.client.spin()
         self.client.close()
         BaseZMQTestCase.tearDown(self)
         # this will be redundant when pyzmq merges PR #88

--- a/ipyparallel/tests/test_client.py
+++ b/ipyparallel/tests/test_client.py
@@ -210,7 +210,6 @@ class TestClient(ClusterTestCase):
         self.client.shutdown(id0, block=True)
         while id0 in self.client.ids:
             time.sleep(0.1)
-            self.client.spin()
         
         self.assertRaises(IndexError, lambda : self.client[id0])
         
@@ -436,7 +435,6 @@ class TestClient(ClusterTestCase):
         self.client.purge_hub_results(hist[-1])
         newhist = self.client.hub_history()
         self.assertEqual(len(newhist)+1,len(hist))
-        rc2.spin()
         rc2.close()
 
     def test_purge_local_results(self):
@@ -516,28 +514,6 @@ class TestClient(ClusterTestCase):
         # the hub results
         hist = self.client.hub_history()
         self.assertEqual(len(hist), 0, msg="hub history not empty")
-        
-    
-    def test_spin_thread(self):
-        self.client.spin_thread(0.01)
-        ar = self.client[-1].apply_async(lambda : 1)
-        md = self.client.metadata[ar.msg_ids[0]]
-        # 3s timeout, 100ms poll
-        for i in range(30):
-            time.sleep(0.1)
-            if md['received'] is not None:
-                break
-        self.assertIsInstance(md['received'], datetime)
-    
-    def test_stop_spin_thread(self):
-        self.client.spin_thread(0.01)
-        self.client.stop_spin_thread()
-        ar = self.client[-1].apply_async(lambda : 1)
-        md = self.client.metadata[ar.msg_ids[0]]
-        # 500ms timeout, 100ms poll
-        for i in range(5):
-            time.sleep(0.1)
-            self.assertIsNone(md['received'], None)
     
     def test_activate(self):
         ip = get_ipython()

--- a/ipyparallel/tests/test_lbview.py
+++ b/ipyparallel/tests/test_lbview.py
@@ -49,7 +49,6 @@ class TestLoadBalancedView(ClusterTestCase):
         tic = time.time()
         while eid in self.client.ids and time.time()-tic < 5:
             time.sleep(.01)
-            self.client.spin()
         self.assertFalse(eid in self.client.ids, "Engine should have died")
 
     def test_map(self):

--- a/ipyparallel/tests/test_view.py
+++ b/ipyparallel/tests/test_view.py
@@ -52,7 +52,6 @@ class TestView(ClusterTestCase):
         tic = time.time()
         while eid in self.client.ids and time.time()-tic < 5:
             time.sleep(.01)
-            self.client.spin()
         self.assertFalse(eid in self.client.ids, "Engine should have died")
     
     def test_push_pull(self):
@@ -148,7 +147,6 @@ class TestView(ClusterTestCase):
         ar2 = v2.get_result(ar.msg_ids[0])
         self.assertNotIsInstance(ar2, AsyncHubResult)
         self.assertEqual(ahr.get(), ar2.get())
-        c.spin()
         c.close()
     
     def test_run_newline(self):

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ install_requires = setuptools_args['install_requires'] = [
     'ipython>=4',
     'jupyter_client',
     'ipykernel',
+    'tornado>=4',
 ]
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
using tornado IOLoop, Futures, and Events for synchronization.

Gets rid of:

- wait_for_output
- Client.spin

Related to #53