### PR TITLE
test with stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install -f travis-wheels/wheelhouse --pre . coveralls
+    - pip install -f travis-wheels/wheelhouse . coveralls
 script:
     - iptest --coverage xml ipyparallel.tests
 after_success:


### PR DESCRIPTION
--pre is pulling in traitlets 4.1b which causes failure to teardown the interpreter in py35