### PR TITLE
AsyncResults are Futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
 install:
     - pip install -f travis-wheels/wheelhouse . coveralls
 script:
-    - iptest --coverage xml ipyparallel.tests
+    - iptest --coverage xml ipyparallel.tests -- -vsx
 after_success:
     - coveralls

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -606,11 +606,11 @@ class AsyncMapResult(AsyncResult):
     
     """
 
-    def __init__(self, client, msg_ids, mapObject, fname='', ordered=True):
-        AsyncResult.__init__(self, client, msg_ids, fname=fname)
+    def __init__(self, client, children, mapObject, fname='', ordered=True):
         self._mapObject = mapObject
-        self._single_result = False
         self.ordered = ordered
+        AsyncResult.__init__(self, client, children, fname=fname)
+        self._single_result = False
 
     def _reconstruct_result(self, res):
         """Perform the gather on the actual results."""

--- a/ipyparallel/client/remotefunction.py
+++ b/ipyparallel/client/remotefunction.py
@@ -216,7 +216,7 @@ class ParallelFunction(RemoteFunction):
                 targets = [targets]
             nparts = len(targets)
 
-        msg_ids = []
+        futures = []
         for index, t in enumerate(targets):
             args = []
             for seq in sequences:
@@ -238,10 +238,11 @@ class ParallelFunction(RemoteFunction):
             view = self.view if balanced else client[t]
             with view.temp_flags(block=False, **self.flags):
                 ar = view.apply(f, *args)
+                ar.owner = False
 
-            msg_ids.extend(ar.msg_ids)
+            futures.extend(ar._children)
 
-        r = AsyncMapResult(self.view.client, msg_ids, self.mapObject,
+        r = AsyncMapResult(self.view.client, futures, self.mapObject,
                             fname=getname(self.func),
                             ordered=self.ordered
                         )

--- a/ipyparallel/tests/__init__.py
+++ b/ipyparallel/tests/__init__.py
@@ -92,7 +92,6 @@ def add_engines(n=1, profile='iptest', total=False):
         ep = TestProcessLauncher()
         ep.cmd_and_args = ipengine_cmd_argv + [
             '--profile=%s' % profile,
-            '--log-level=50',
             '--InteractiveShell.colors=nocolor'
             ]
         ep.start()

--- a/ipyparallel/tests/test_lbview.py
+++ b/ipyparallel/tests/test_lbview.py
@@ -128,7 +128,7 @@ class TestLoadBalancedView(ClusterTestCase):
         astheycame = list(amr)
         # Ensure that results came in order
         self.assertEqual(astheycame, reference)
-        self.assertEqual(amr.result, reference)
+        self.assertEqual(amr.get(), reference)
 
     def test_map_iterable(self):
         """test map on iterables (balanced)"""

--- a/ipyparallel/tests/test_magics.py
+++ b/ipyparallel/tests/test_magics.py
@@ -276,11 +276,10 @@ class TestParallelMagics(ClusterTestCase):
             ip.magic('autopx')
         
         output = io.stdout.rstrip()
-        
         assert output.startswith('%autopx enabled'), output
         assert output.endswith('%autopx disabled'), output
         self.assertNotIn('ZeroDivisionError', output)
-        ar = v.get_result(-2)
+        ar = v.get_result(-2, owner=False)
         self.assertRaisesRemote(ZeroDivisionError, ar.get)
         # prevent TaskAborted on pulls, due to ZeroDivisionError
         time.sleep(0.5)

--- a/ipyparallel/tests/test_view.py
+++ b/ipyparallel/tests/test_view.py
@@ -655,12 +655,11 @@ class TestView(ClusterTestCase):
     def test_compositeerror_truncate(self):
         """Truncate CompositeErrors with many exceptions"""
         view = self.client[:]
-        msg_ids = []
+        requests = []
         for i in range(10):
-            ar = view.execute("1/0")
-            msg_ids.extend(ar.msg_ids)
+            requests.append(view.execute("1/0"))
         
-        ar = self.client.get_result(msg_ids)
+        ar = self.client.get_result(requests)
         try:
             ar.get()
         except error.CompositeError as _e:

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
+    ':python_version == "2.7"': ['futures'],
     'nbext': ["notebook"],
 }
 


### PR DESCRIPTION
This is the big piece in enabling an Executor API.

I'm not 100% sure it's the right move for AsyncResult to *be* a Future, as opposed to providing a separate Future API.

Futures also make it feasible to eliminate the local result/metadata cache, though it's not quite there yet.