### PR TITLE
send-tracking changes

### DIFF
--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -47,6 +47,7 @@ from jupyter_client.session import Session
 from ipyparallel import serialize
 
 from .asyncresult import AsyncResult, AsyncHubResult
+from .futures import MessageFuture
 from .view import DirectView, LoadBalancedView
 
 #--------------------------------------------------------------------------
@@ -70,34 +71,6 @@ def unpack_message(f, self, msg_parts):
 #--------------------------------------------------------------------------
 # Classes
 #--------------------------------------------------------------------------
-
-
-class MessageFuture(Future):
-    """Future class to wrap async messages"""
-    def __init__(self, msg_id, track=False):
-        super(MessageFuture, self).__init__()
-        self.msg_id = msg_id
-        self._evt = Event()
-        self.track = track
-        self._tracker = None
-        if track:
-            self._tracker_evt = Event()
-        else:
-            self._tracker_evt = None
-        self.add_done_callback(lambda f: self._evt.set())
-    
-    def wait(self, timeout=None):
-        if not self.done():
-            return self._evt.wait(timeout)
-        return True
-    
-    @property
-    def tracker(self):
-        if not self.track:
-            return None
-        else:
-            self._tracker_evt.wait()
-            return self._tracker
 
 
 _no_connection_file_msg = """
@@ -982,8 +955,7 @@ class Client(HasTraits):
         def _really_send():
             sent = self.session.send(socket, msg, track=track, buffers=buffers, ident=ident)
             if track:
-                future._tracker = sent['tracker']
-                future._tracker_evt.set()
+                future.tracker.set_result(sent['tracker'])
         
         # hand off actual send to IO thread
         self._io_loop.add_callback(_really_send)

--- a/ipyparallel/client/futures.py
+++ b/ipyparallel/client/futures.py
@@ -1,0 +1,27 @@
+"""Future-related utils"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from threading import Event
+from tornado.concurrent import Future
+
+class MessageFuture(Future):
+    """Future class to wrap async messages"""
+    def __init__(self, msg_id, track=False):
+        super(MessageFuture, self).__init__()
+        self.msg_id = msg_id
+        self._evt = Event()
+        self.track = track
+        self._tracker = None
+        self.tracker = Future()
+        if not track:
+            self.tracker.set_result(None)
+        self.add_done_callback(lambda f: self._evt.set())
+    
+    def wait(self, timeout=None):
+        if not self.done():
+            return self._evt.wait(timeout)
+        return True
+
+

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -90,11 +90,11 @@ class View(HasTraits):
 
     """
     # flags
-    block=Bool(False)
-    track=Bool(True)
+    block = Bool(False)
+    track = Bool(False)
     targets = Any()
 
-    history=List()
+    history = List()
     outstanding = Set()
     results = Dict()
     client = Instance('ipyparallel.Client', allow_none=True)

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -555,10 +555,7 @@ class DirectView(View):
             trackers = []
         if isinstance(targets, int):
             futures = futures[0]
-        tracker = None if track is False else zmq.MessageTracker(*trackers)
-        ar = AsyncResult(self.client, futures, fname=getname(f), targets=_targets,
-            tracker=tracker, owner=True,
-        )
+        ar = AsyncResult(self.client, futures, fname=getname(f), targets=_targets, owner=True)
         if block:
             try:
                 return ar.get()
@@ -747,17 +744,8 @@ class DirectView(View):
             r = self.push(ns, block=False, track=track, targets=engineid)
             r.owner = False
             futures.extend(r._children)
-            if track:
-                trackers.append(r._tracker)
 
-        if track:
-            tracker = zmq.MessageTracker(*trackers)
-        else:
-            tracker = None
-
-        r = AsyncResult(self.client, futures, fname='scatter', targets=targets,
-            tracker=tracker, owner=True,
-        )
+        r = AsyncResult(self.client, futures, fname='scatter', targets=targets, owner=True)
         if block:
             r.wait()
         else:
@@ -1040,10 +1028,9 @@ class LoadBalancedView(View):
 
         future = self.client.send_apply_request(self._socket, f, args, kwargs, track=track,
                                 metadata=metadata)
-        tracker = None if track is False else future.tracker
 
         ar = AsyncResult(self.client, future, fname=getname(f),
-            targets=None, tracker=tracker, owner=True,
+            targets=None, owner=True,
         )
         if block:
             try:

--- a/ipyparallel/tests/test_asyncresult.py
+++ b/ipyparallel/tests/test_asyncresult.py
@@ -3,6 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import os
 import time
 
 import nose.tools as nt
@@ -329,4 +330,14 @@ class AsyncResultTest(ClusterTestCase):
         d = dir(ar)
         self.assertIn('stdout', d)
         self.assertIn('get', d)
+    
+    def test_wait_for_send(self):
+        view = self.client[-1]
+        view.track = True
+        data = os.urandom(10*1024*1024)
+        ar = view.apply_async(lambda x:x, data)
+        with self.assertRaises(error.TimeoutError):
+            ar.wait_for_send(0)
+        ar.wait_for_send(10)
+    
 


### PR DESCRIPTION
- disable send-tracking by default because it's quite expensive and rarely used
- rework send-tracking with Futures
  to resolve the fact that the MessageTracker doesn't exist when send returns
  without a property-based wait.