### PR TITLE
Update doc links to stop linkcheck errors

### DIFF
--- a/docs/source/asyncresult.rst
+++ b/docs/source/asyncresult.rst
@@ -18,7 +18,7 @@ Beyond multiprocessing's AsyncResult
 
     The :class:`~.AsyncResult` object provides a superset of the interface in
     :py:class:`multiprocessing.pool.AsyncResult`.  See the
-    `official Python documentation <http://docs.python.org/library/multiprocessing#multiprocessing.pool.AsyncResult>`_
+    `official Python documentation <https://docs.python.org/library/multiprocessing#multiprocessing.pool.AsyncResult>`_
     for more on the basics of this interface.
 
 Our AsyncResult objects add a number of convenient features for working with

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ exec(compile(open('../../ipyparallel/_version.py').read(), '../../ipyparallel/_v
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -100,7 +100,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['winhpc.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -318,6 +318,5 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('http://docs.python.org/3/', None),
-                       'ipython': ('http://ipython.org/ipython-doc/dev/', None),}
-
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
+                       'ipython': ('https://ipython.org/ipython-doc/dev/', None),}

--- a/docs/source/dag_dependencies.rst
+++ b/docs/source/dag_dependencies.rst
@@ -5,7 +5,7 @@ DAG Dependencies
 ================
 
 Often, parallel workflow is described in terms of a `Directed Acyclic Graph
-<http://en.wikipedia.org/wiki/Directed_acyclic_graph>`_ or DAG.  A popular library
+<https://en.wikipedia.org/wiki/Directed_acyclic_graph>`_ or DAG.  A popular library
 for working with Graphs is NetworkX_.  Here, we will walk through a demo mapping
 a nx DAG to task dependencies.
 
@@ -174,4 +174,4 @@ will be at the top, and quick, small tasks will be at the bottom.
     were four engines). Edges denote dependencies.
 
 
-.. _NetworkX: http://networkx.lanl.gov/
+.. _NetworkX: https://networkx.github.io/

--- a/docs/source/db.rst
+++ b/docs/source/db.rst
@@ -7,7 +7,7 @@ IPython's Task Database
 Enabling a DB Backend
 =====================
 
-The IPython Hub can store all task requests and results in a database. 
+The IPython Hub can store all task requests and results in a database.
 Currently supported backends are: MongoDB, SQLite, and an in-memory DictDB.
 
 This database behavior is optional due to its potential :ref:`db_cost`,
@@ -36,12 +36,12 @@ The most common use case for this is clients requesting results for tasks they d
 However, since we have this DB backend, we provide a direct query method in the :class:`~.Client`
 for users who want deeper introspection into their task history. The :meth:`db_query` method of
 the Client is modeled after MongoDB queries, so if you have used MongoDB it should look
-familiar.  In fact, when the MongoDB backend is in use, the query is relayed directly.  
+familiar.  In fact, when the MongoDB backend is in use, the query is relayed directly.
 When using other backends, the interface is emulated and only a subset of queries is possible.
 
 .. seealso::
 
-    MongoDB query docs: http://www.mongodb.org/display/DOCS/Querying
+    MongoDB query docs: https://docs.mongodb.org/manual/tutorial/query-documents/
 
 :meth:`Client.db_query` takes a dictionary query object, with keys from the TaskRecord key list,
 and values of either exact values to test, or MongoDB queries, which are dicts of The form:
@@ -155,5 +155,3 @@ and any request for results will result in a KeyError.  This obviously prevents
 later requests for results and task resubmission from functioning, but
 sometimes those nice features are not as useful as keeping Hub memory under
 control.
-
-

--- a/docs/source/development/messages.rst
+++ b/docs/source/development/messages.rst
@@ -248,7 +248,7 @@ Message type: ``task_destination``::
 In terms of message classes, the MUX scheduler and Task scheduler relay the exact same
 message types.  Their only difference lies in how the destination is selected.
 
-The `Namespace <http://gist.github.com/483294>`_ model suggests that execution be able to
+The Namespace model suggests that execution be able to
 use the model::
 
     ns.apply(f, *args, **kwargs)
@@ -394,4 +394,3 @@ This allows the controller to unpack and inspect the (always small) header,
 without spending time unpacking the content unless the message is bound for the
 controller. Buffers are added on to the end of the message, and can be any objects that
 present the buffer interface.
-

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -66,7 +66,7 @@ the ``I`` in IPython.  The following are some example usage cases for IPython:
    excellent, hands-on oriented complement to the reference documentation
    presented here.
 
-.. __: http://minrk.github.com/scipy-tutorial-2011
+.. __: https://minrk.github.io/scipy-tutorial-2011/
 
 Architecture overview
 =====================
@@ -300,4 +300,4 @@ You are now ready to learn more about the :ref:`Direct
 <parallel_multiengine>` and :ref:`LoadBalanced <parallel_task>` interfaces to the
 controller.
 
-.. [ZeroMQ] ZeroMQ.  http://www.zeromq.org
+.. [ZeroMQ] http://zeromq.org/

--- a/docs/source/magics.rst
+++ b/docs/source/magics.rst
@@ -45,7 +45,7 @@ specified by the :attr:`targets` attribute of the :class:`DirectView` instance:
     Out [1:68]: array([ 1.10815921,  0.05110369])
     Out [2:68]: array([ 0.74625527, -0.37475081])
     Out [3:68]: array([ 0.72931905,  0.07159743])
-    
+
     In [29]: %px print 'hi'
     Parallel execution on engine(s): all
     [stdout:0] hi
@@ -60,13 +60,13 @@ Since engines are IPython as well, you can even run magics remotely:
 
     In [28]: %px %pylab inline
     Parallel execution on engine(s): all
-    [stdout:0] 
+    [stdout:0]
     Populating the interactive namespace from numpy and matplotlib
-    [stdout:1] 
+    [stdout:1]
     Populating the interactive namespace from numpy and matplotlib
-    [stdout:2] 
+    [stdout:2]
     Populating the interactive namespace from numpy and matplotlib
-    [stdout:3] 
+    [stdout:3]
     Populating the interactive namespace from numpy and matplotlib
 
 And once in pylab mode with the inline backend,
@@ -105,20 +105,20 @@ independent of the defaults for the View.
 
     In [6]: %%px --targets ::2
        ...: print "I am even"
-       ...: 
+       ...:
     Parallel execution on engine(s): [0, 2]
     [stdout:0] I am even
     [stdout:2] I am even
 
     In [7]: %%px --targets 1
        ...: print "I am number 1"
-       ...: 
+       ...:
     Parallel execution on engine(s): 1
     I am number 1
 
     In [8]: %%px
        ...: print "still 'all' by default"
-       ...: 
+       ...:
     Parallel execution on engine(s): all
     [stdout:0] still 'all' by default
     [stdout:1] still 'all' by default
@@ -129,7 +129,7 @@ independent of the defaults for the View.
        ...: import time
        ...: time.sleep(1)
        ...: time.time()
-       ...: 
+       ...:
     Async parallel execution on engine(s): all
     Out[9]: <AsyncResult: execute>
 
@@ -187,10 +187,10 @@ just as is done when %px is blocking:
 .. sourcecode:: ipython
 
     In [39]: dv.block = False
-    
+
     In [40]: %px print 'hi'
     Async parallel execution on engine(s): all
-    
+
     In [41]: %pxresult
     [stdout:0] hi
     [stdout:1] hi
@@ -358,24 +358,24 @@ depending on where they live and where you are:
 
     In [51]: %px %connect_info
     Parallel execution on engine(s): all
-    [stdout:0] 
+    [stdout:0]
     {
-      "stdin_port": 60387, 
-      "ip": "127.0.0.1", 
-      "hb_port": 50835, 
-      "key": "eee2dd69-7dd3-4340-bf3e-7e2e22a62542", 
-      "shell_port": 55328, 
+      "stdin_port": 60387,
+      "ip": "127.0.0.1",
+      "hb_port": 50835,
+      "key": "eee2dd69-7dd3-4340-bf3e-7e2e22a62542",
+      "shell_port": 55328,
       "iopub_port": 58264
     }
 
     Paste the above JSON into a file, and connect with:
         $> ipython <app> --existing <file>
     or, if you are local, you can connect with just:
-        $> ipython <app> --existing kernel-60125.json 
+        $> ipython <app> --existing kernel-60125.json
     or even just:
-        $> ipython <app> --existing 
+        $> ipython <app> --existing
     if this is the most recent IPython session you have started.
-    [stdout:1] 
+    [stdout:1]
     {
       "stdin_port": 61869,
     ...
@@ -384,5 +384,3 @@ depending on where they live and where you are:
 
     ``%qtconsole`` will call :func:`bind_kernel` on an engine if it hasn't been done already,
     so you can often skip that first step.
-
-

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -106,7 +106,7 @@ distributed array. Save the following text in a file called :file:`psum.py`:
 Now, start an IPython cluster::
 
     $ ipcluster start --profile=mpi -n 4
-    
+
 .. note::
 
     It is assumed here that the mpi profile has been set up, as described :ref:`here
@@ -146,9 +146,7 @@ manner using our :func:`psum` function:
 Any Python code that makes calls to MPI can be used in this manner, including
 compiled C, C++ and Fortran libraries that have been exposed to Python.
 
-.. [MPI] Message Passing Interface.  http://www-unix.mcs.anl.gov/mpi/
+.. [MPI] Message Passing Interface.  http://www-unix.mcs.anl.gov/research/projects/mpi/
 .. [mpi4py] MPI for Python. mpi4py: http://mpi4py.scipy.org/
 .. [OpenMPI] Open MPI. http://www.open-mpi.org/
-.. [PyTrilinos] PyTrilinos. http://trilinos.sandia.gov/packages/pytrilinos/
-
-
+.. [PyTrilinos] PyTrilinos. https://trilinos.org/

--- a/docs/source/process.rst
+++ b/docs/source/process.rst
@@ -12,7 +12,7 @@ Because of this, there are many different possibilities.
 Broadly speaking, there are two ways of going about starting a controller and engines:
 
 * In an automated manner using the :command:`ipcluster` command.
-* In a more manual way using the :command:`ipcontroller` and 
+* In a more manual way using the :command:`ipcontroller` and
   :command:`ipengine` commands.
 
 This document describes both of these methods. We recommend that new users
@@ -62,7 +62,7 @@ Or you can set the same behavior as the default by adding the following line to 
     localhost by default. If you see Timeout errors on engines or clients, then the first
     thing you should check is the ip address the controller is listening on, and make sure
     that it is visible from the timing out machine.
-    
+
 .. seealso::
 
     Our `notes <parallel_security>`_ on security in the new parallel computing code.
@@ -74,10 +74,10 @@ hosts ``host1``-``hostn``. The following steps are then required:
    ``host0``.  The controller must be instructed to listen on an interface visible
    to the engine machines, via the ``ip`` command-line argument or ``HubFactory.ip``
    in :file:`ipcontroller_config.py`.
-2. Move the JSON file (:file:`ipcontroller-engine.json`) created by the 
+2. Move the JSON file (:file:`ipcontroller-engine.json`) created by the
    controller from ``host0`` to hosts ``host1``-``hostn``.
-3. Start the engines on hosts ``host1``-``hostn`` by running 
-   :command:`ipengine`.  This command has to be told where the JSON file 
+3. Start the engines on hosts ``host1``-``hostn`` by running
+   :command:`ipengine`.  This command has to be told where the JSON file
    (:file:`ipcontroller-engine.json`) is located.
 
 At this point, the controller and engines will be connected. By default, the JSON files
@@ -99,11 +99,11 @@ controller and engines in the following situations:
 
 1. When the controller and engines are all run on localhost. This is useful
    for testing or running on a multicore computer.
-2. When engines are started using the :command:`mpiexec` command that comes 
+2. When engines are started using the :command:`mpiexec` command that comes
    with most MPI [MPI]_ implementations
-3. When engines are started using the PBS [PBS]_ batch system 
+3. When engines are started using the PBS [PBS]_ batch system
    (or other `qsub` systems, such as SGE).
-4. When the controller is started on localhost and the engines are started on 
+4. When the controller is started on localhost and the engines are started on
    remote nodes using :command:`ssh`.
 5. When engines are started using the Windows HPC Server batch system.
 
@@ -119,7 +119,7 @@ Under the hood, :command:`ipcluster` just uses :command:`ipcontroller`
 and :command:`ipengine` to perform the steps described above.
 
 The simplest way to use ipcluster requires no configuration, and will
-launch a controller and a number of engines on the local machine. For instance, 
+launch a controller and a number of engines on the local machine. For instance,
 to start one controller and 4 engines on localhost, just do::
 
     $ ipcluster start -n 4
@@ -258,7 +258,7 @@ More details on using MPI with IPython can be found :ref:`here <parallelmpi>`.
 Using :command:`ipcluster` in PBS mode
 --------------------------------------
 
-The PBS mode uses the Portable Batch System (PBS) to start the engines. 
+The PBS mode uses the Portable Batch System (PBS) to start the engines.
 
 As usual, we will start by creating a fresh profile::
 
@@ -338,9 +338,9 @@ Once you have created these scripts, save them with names like
 .. sourcecode:: python
 
     c.PBSEngineSetLauncher.batch_template_file = "pbs.engine.template"
-    
+
     c.PBSControllerLauncher.batch_template_file = "pbs.controller.template"
-        
+
 
 Alternately, you can just define the templates as strings inside :file:`ipcluster_config`.
 
@@ -411,7 +411,7 @@ The controller's remote location and configuration can be specified:
     # c.SSHControllerLauncher.user = os.environ.get('USER','username')
 
     # Set the arguments to be passed to ipcontroller
-    # note that remotely launched ipcontroller will not get the contents of 
+    # note that remotely launched ipcontroller will not get the contents of
     # the local ipcontroller_config.py unless it resides on the *remote host*
     # in the location specified by the `profile-dir` argument.
     # c.SSHControllerLauncher.controller_args = ['--reuse', '--ip=*', '--profile-dir=/path/to/cd']
@@ -431,10 +431,10 @@ on that host.
   the value is the number of engines to run on that host.
 * on host3, the value is a tuple, where the number of engines is first, and the arguments
   to be passed to :command:`ipengine` are the second element.
-* on host4, a dictionary configures the engine. The dictionary can be used to specify 
-  the number of engines to be run on that host `n`, the engine arguments `engine_args`, 
-  as well as the engine command itself `engine_cmd`. This is particularly useful for 
-  virtual environments on heterogeneous clusters where the location of the python 
+* on host4, a dictionary configures the engine. The dictionary can be used to specify
+  the number of engines to be run on that host `n`, the engine arguments `engine_args`,
+  as well as the engine command itself `engine_cmd`. This is particularly useful for
+  virtual environments on heterogeneous clusters where the location of the python
   executable might vary from host to host.
 
 For engines without explicitly specified arguments, the default arguments are set in
@@ -462,8 +462,8 @@ unnecessary, and can be skipped by setting these to empty lists:
     c.SSHLauncher.to_send = []
     c.SSHLauncher.to_fetch = []
 
-If our default guesses about paths don't work for you, or other files 
-should be moved, you can manually specify these lists as tuples of (local_path, 
+If our default guesses about paths don't work for you, or other files
+should be moved, you can manually specify these lists as tuples of (local_path,
 remote_path) for to_send, and (remote_path, local_path) for to_fetch.  If you do
 specify these lists explicitly, IPython *will not* automatically send connection files,
 so you must include this yourself if they should still be sent/retrieved.
@@ -477,9 +477,9 @@ which makes deploying IPython on EC2 quite simple.  The starcluster plugin uses
 :command:`ipcluster` with the SGE launchers to distribute engines across the
 EC2 cluster.  See their `ipcluster plugin documentation`_ for more information.
 
-.. _StarCluster: http://web.mit.edu/starcluster
+.. _StarCluster: http://star.mit.edu/cluster
 .. _Amazon EC2: http://aws.amazon.com/ec2/
-.. _ipcluster plugin documentation: http://web.mit.edu/starcluster/docs/latest/plugins/ipython.html
+.. _ipcluster plugin documentation: http://star.mit.edu/cluster/docs/latest/plugins/ipython.html
 
 
 Using the :command:`ipcontroller` and :command:`ipengine` commands
@@ -498,7 +498,7 @@ local machine, do the following.
 First start the controller::
 
     $ ipcontroller
-    
+
 Next, start however many instances of the engine you want using (repeatedly)
 the command::
 
@@ -508,8 +508,8 @@ The engines should start and automatically connect to the controller using the
 JSON files in :file:`IPYTHONDIR/profile_default/security`. You are now ready to use the
 controller and engines from IPython.
 
-.. warning:: 
-    
+.. warning::
+
     The order of the above operations may be important.  You *must*
     start the controller before the engines, unless you are reusing connection
     information (via ``--reuse``), in which case ordering is not important.
@@ -530,11 +530,11 @@ slightly more complicated, but the underlying ideas are the same:
 1. Start the controller on a host using :command:`ipcontroller`. The controller must be
    instructed to listen on an interface visible to the engine machines, via the ``ip``
    command-line argument or ``HubFactory.ip`` in :file:`ipcontroller_config.py`::
-   
+
         $ ipcontroller --ip=192.168.1.16
-   
+
    .. sourcecode:: python
-   
+
         # in ipcontroller_config.py
         HubFactory.ip = '192.168.1.16'
 
@@ -556,8 +556,8 @@ The ``file`` flag works like this::
     $ ipengine --file=/path/to/my/ipcontroller-engine.json
 
 .. note::
-    
-    If the controller's and engine's hosts all have a shared file system  
+
+    If the controller's and engine's hosts all have a shared file system
     (:file:`IPYTHONDIR/profile_<name>/security` is the same on all of them), then things
     will just work!
 
@@ -573,7 +573,7 @@ use SSH tunnels to connect engines to the controller.
     This does not work in all cases.  Manual tunnels may be an option, but are
     highly inconvenient. Support for manual tunnels will be improved.
 
-You can instruct all engines to use ssh, by specifying the ssh server in 
+You can instruct all engines to use ssh, by specifying the ssh server in
 :file:`ipcontroller-engine.json`:
 
 .. I know this is really JSON, but the example is a subset of Python:
@@ -614,7 +614,7 @@ the engines.
 1. start the controller, listening on an ip-address visible to the engine machines::
 
     [controller.host] $ ipcontroller --ip=192.168.1.16
-    
+
     [IPControllerApp] Using existing profile dir: u'/Users/me/.ipython/profile_default'
     [IPControllerApp] Hub listening on tcp://192.168.1.16:63320 for registration.
     [IPControllerApp] Hub using DB backend: 'ipyparallel.controller.dictdb.DictDB'
@@ -707,7 +707,7 @@ Ports and addresses
 
 In many cases, you will want to configure the Controller's network identity.  By default,
 the Controller listens only on loopback, which is the most secure but often impractical.
-To instruct the controller to listen on a specific interface, you can set the 
+To instruct the controller to listen on a specific interface, you can set the
 :attr:`HubFactory.ip` trait.  To listen on all interfaces, simply specify:
 
 .. sourcecode:: python
@@ -731,7 +731,7 @@ through the login node, an example :file:`ipcontroller_config.py` might contain:
     # engines on the same node will use loopback, while engines
     # from other nodes will use an external IP
     c.HubFactory.ip = '*'
-    
+
     # you typically only need to specify the location when there are extra
     # interfaces that may not be visible to peer nodes (e.g. VM interfaces)
     c.HubFactory.location = '10.0.1.5'
@@ -740,10 +740,10 @@ through the login node, an example :file:`ipcontroller_config.py` might contain:
     hostname = socket.gethostname()
     # alternate choices for hostname include `socket.getfqdn()`
     # or `socket.gethostname() + '.local'`
-    
+
     ex_ip = socket.gethostbyname_ex(hostname)[-1][-1]
     c.HubFactory.location = ex_ip
-    
+
     # now instruct clients to use the login node for SSH tunnels:
     c.HubFactory.ssh_server = 'login.mycluster.net'
 
@@ -779,7 +779,7 @@ data types.
 
 .. seealso::
 
-    MongoDB `BSON doc <http://www.mongodb.org/display/DOCS/BSON>`_
+    MongoDB `BSON doc <http://bsonspec.org/>`_
 
 To use one of these backends, you must set the :attr:`HubFactory.db_class` trait:
 
@@ -788,13 +788,13 @@ To use one of these backends, you must set the :attr:`HubFactory.db_class` trait
     # for a simple dict-based in-memory implementation, use dictdb
     # This is the default and the fastest, since it doesn't involve the filesystem
     c.HubFactory.db_class = 'ipyparallel.controller.dictdb.DictDB'
-    
+
     # To use MongoDB:
     c.HubFactory.db_class = 'ipyparallel.controller.mongodb.MongoDB'
-    
+
     # and SQLite:
     c.HubFactory.db_class = 'ipyparallel.controller.sqlitedb.SQLiteDB'
-    
+
     # You can use NoDB to disable the database altogether, in case you don't need
     # to reuse tasks or results, and want to keep memory consumption under control.
     c.HubFactory.db_class = 'ipyparallel.controller.dictdb.NoDB'
@@ -808,20 +808,20 @@ which is a UUID, and thus different every time.
 
     # To keep persistent task history in MongoDB:
     c.MongoDB.database = 'tasks'
-    
+
     # and in SQLite:
     c.SQLiteDB.table = 'tasks'
 
 
 Since MongoDB servers can be running remotely or configured to listen on a particular port,
-you can specify any arguments you may need to the PyMongo `Connection 
+you can specify any arguments you may need to the PyMongo `Connection
 <http://api.mongodb.org/python/1.9/api/pymongo/connection.html#pymongo.connection.Connection>`_:
 
 .. sourcecode:: python
 
     # positional args to pymongo.Connection
     c.MongoDB.connection_args = []
-    
+
     # keyword args to pymongo.Connection
     c.MongoDB.connection_kwargs = {}
 
@@ -869,7 +869,7 @@ Engine:
 .. sourcecode:: python
 
     c.IPEngineApp.startup_script = u'/path/to/my/startup.py'
-    
+
     c.IPEngineApp.startup_command = 'import numpy, scipy, mpi4py'
 
 These commands/files will be run again, after each
@@ -883,8 +883,8 @@ in some scratch directory.  This can be set with:
 
 
 
-.. [MongoDB] MongoDB database http://www.mongodb.org
+.. [MongoDB] MongoDB database https://www.mongodb.org/
 
-.. [PBS] Portable Batch System http://www.openpbs.org
+.. [PBS] Portable Batch System http://www.mcs.anl.gov/research/projects/openpbs/
 
-.. [SSH] SSH-Agent http://en.wikipedia.org/wiki/ssh-agent
+.. [SSH] SSH-Agent https://en.wikipedia.org/wiki/Ssh-agent

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -25,7 +25,7 @@ are summarized here:
 * The IPython *engine*.  This process is a full blown Python
   interpreter in which user code is executed.  Multiple
   engines are started to make parallel computing possible.
-* The IPython *hub*.  This process monitors a set of 
+* The IPython *hub*.  This process monitors a set of
   engines and schedulers, and keeps track of the state of the processes. It listens
   for registration connections from engines and clients, and monitor connections
   from schedulers.
@@ -86,7 +86,7 @@ arbitrary execution as the user on the engine machines. As a result, the default
 of controller processes is to only listen for clients on the loopback interface, and the
 client must establish SSH tunnels to connect to the controller processes.
 
-.. warning:: 
+.. warning::
 
     If the controller's loopback interface is untrusted, then IPython should be considered
     vulnerable, and this extends to the loopback of all connected clients, which have
@@ -232,7 +232,7 @@ or:
 
 * The user has to use SSH port forwarding to tunnel the
   connections through the firewall.
-   
+
 In either case, an attacker is presented with additional barriers that prevent
 attacking or even probing the system.
 
@@ -247,5 +247,5 @@ while still enabling user's to use the system in open networks.
 .. [RFC5246] <http://tools.ietf.org/html/rfc5246>
 
 .. [OpenSSH] <http://www.openssh.com/>
-.. [Paramiko] <http://www.lag.net/paramiko/>
+.. [Paramiko] <https://www.lag.net/paramiko/>
 .. [HMAC] <http://tools.ietf.org/html/rfc2104.html>

--- a/docs/source/task.rst
+++ b/docs/source/task.rst
@@ -25,7 +25,7 @@ controller and four IPython engines. The simplest way of doing this is to use
 the :command:`ipcluster` command::
 
 	$ ipcluster start -n 4
-	
+
 For more detailed information about starting the controller and engines, see
 our :ref:`introduction <parallel_overview>` to using IPython for parallel computing.
 
@@ -41,7 +41,7 @@ a :class:`LoadBalancedView`, here called `lview`:
     In [1]: from ipyparallel import Client
 
     In [2]: rc = Client()
-    
+
 
 This form assumes that the controller was started on localhost with default
 configuration. If not, the location of the controller must be given as an
@@ -84,9 +84,9 @@ Parallel map
 To load-balance :meth:`map`,simply use a LoadBalancedView:
 
 .. sourcecode:: ipython
-    
+
     In [62]: lview.block = True
-    
+
     In [63]: serial_result = map(lambda x:x**10, range(32))
 
     In [64]: parallel_result = lview.map(lambda x:x**10, range(32))
@@ -118,7 +118,7 @@ Dependencies
 
 Often, pure atomic load-balancing is too primitive for your work. In these cases, you
 may want to associate some kind of `Dependency` that describes when, where, or whether
-a task can be run.  In IPython, we provide two types of dependencies: 
+a task can be run.  In IPython, we provide two types of dependencies:
 `Functional Dependencies`_ and `Graph Dependencies`_
 
 .. note::
@@ -131,14 +131,14 @@ Functional Dependencies
 -----------------------
 
 Functional dependencies are used to determine whether a given engine is capable of running
-a particular task.  This is implemented via a special :class:`Exception` class, 
-:class:`UnmetDependency`, found in `ipyparallel.error`.  Its use is very simple: 
+a particular task.  This is implemented via a special :class:`Exception` class,
+:class:`UnmetDependency`, found in `ipyparallel.error`.  Its use is very simple:
 if a task fails with an UnmetDependency exception, then the scheduler, instead of relaying
 the error up to the client like any other error, catches the error, and submits the task
 to a different engine.  This will repeat indefinitely, and a task will never be submitted
 to a given engine a second time.
 
-You can manually raise the :class:`UnmetDependency` yourself, but IPython has provided 
+You can manually raise the :class:`UnmetDependency` yourself, but IPython has provided
 some decorators for facilitating this behavior.
 
 There are two decorators and a class used for functional dependencies:
@@ -193,7 +193,7 @@ will be assigned to another engine. If the dependency returns *anything other th
     In [10]: def platform_specific(plat):
        ....:    import sys
        ....:    return sys.platform == plat
-    
+
     In [11]: @depend(platform_specific, 'darwin')
        ....: def mactask():
        ....:    do_mac_stuff()
@@ -201,7 +201,7 @@ will be assigned to another engine. If the dependency returns *anything other th
     In [12]: @depend(platform_specific, 'nt')
        ....: def wintask():
        ....:    do_windows_stuff()
-    
+
 In this case, any time you apply ``mactask``, it will only run on an OSX machine.
 ``@depend`` is just like ``apply``, in that it has a ``@depend(f,*args,**kwargs)``
 signature.
@@ -217,16 +217,16 @@ the :class:`dependent` object that the decorators use:
 
     In [13]: def mytask(*args):
        ....:    dostuff()
-    
+
     In [14]: mactask = dependent(mytask, platform_specific, 'darwin')
     # this is the same as decorating the declaration of mytask with @depend
     # but you can do it again:
-    
+
     In [15]: wintask = dependent(mytask, platform_specific, 'nt')
-    
+
     # in general:
     In [16]: t = dependent(f, g, *dargs, **dkwargs)
-    
+
     # is equivalent to:
     In [17]: @depend(g, *dargs, **dkwargs)
        ....: def t(a,b,c):
@@ -303,7 +303,7 @@ you can skip using Dependency objects, and just pass msg_ids or AsyncResult obje
 .. seealso::
 
     Some parallel workloads can be described as a `Directed Acyclic Graph
-    <http://en.wikipedia.org/wiki/Directed_acyclic_graph>`_, or DAG. See :ref:`DAG
+    <https://en.wikipedia.org/wiki/Directed_acyclic_graph>`_, or DAG. See :ref:`DAG
     Dependencies <dag_dependencies>` for an example demonstrating how to use map a NetworkX DAG
     onto task dependencies.
 
@@ -355,7 +355,7 @@ a task that is pending - only those that have finished, either successful or uns
 Schedulers
 ==========
 
-There are a variety of valid ways to determine where jobs should be assigned in a 
+There are a variety of valid ways to determine where jobs should be assigned in a
 load-balancing situation.  In IPython, we support several standard schemes, and
 even make it easy to define your own.  The scheme can be selected via the ``scheme``
 argument to :command:`ipcontroller`, or in the :attr:`TaskScheduler.schemename` attribute
@@ -372,7 +372,7 @@ To select one of these schemes, simply do::
 lru: Least Recently Used
 
     Always assign work to the least-recently-used engine.  A close relative of
-    round-robin, it will be fair with respect to the number of tasks, agnostic 
+    round-robin, it will be fair with respect to the number of tasks, agnostic
     with respect to runtime of each task.
 
 plainrandom: Plain Random
@@ -382,7 +382,7 @@ plainrandom: Plain Random
 twobin: Two-Bin Random
 
     **Requires numpy**
-    
+
     Pick two engines at random, and use the LRU of the two. This is known to be better
     than plain random in many cases, but requires a small amount of computation.
 
@@ -395,7 +395,7 @@ leastload: Least Load
 weighted: Weighted Two-Bin Random
 
     **Requires numpy**
-    
+
     Pick two engines at random using the number of outstanding tasks as inverse weights,
     and use the one with the lower load.
 
@@ -442,13 +442,13 @@ load-balancing. This scheduler does not support any of the advanced features of 
 Disabled features when using the ZMQ Scheduler:
 
 * Engine unregistration
-    Task farming will be disabled if an engine unregisters.  
+    Task farming will be disabled if an engine unregisters.
     Further, if an engine is unregistered during computation, the scheduler may not recover.
 * Dependencies
     Since there is no Python logic inside the Scheduler, routing decisions cannot be made
     based on message content.
 * Early destination notification
-    The Python schedulers know which engine gets which task, and notify the Hub.  This 
+    The Python schedulers know which engine gets which task, and notify the Hub.  This
     allows graceful handling of Engines coming and going.  There is no way to know
     where ZeroMQ messages have gone, so there is no way to know what tasks are on which
     engine until they *finish*.  This makes recovery from engine shutdown very difficult.

--- a/docs/source/transition.rst
+++ b/docs/source/transition.rst
@@ -11,7 +11,7 @@ interface for executing code remotely.  This doc is to help users of IPython.ker
 transition their codes to the new code.
 
 .. _0MQ: http://zeromq.org
-.. _Tornado: https://github.com/facebook/tornado
+.. _Tornado: https://github.com/tornadoweb/tornado
 
 
 Processes
@@ -49,18 +49,18 @@ To create a new client, and set up the default direct and load-balanced objects:
 
     # old
     In [1]: from IPython.kernel import client as kclient
-    
+
     In [2]: mec = kclient.MultiEngineClient()
 
     In [3]: tc = kclient.TaskClient()
-    
-    # new 
+
+    # new
     In [1]: from ipyparallel import Client
-    
+
     In [2]: rc = Client()
 
     In [3]: dview = rc[:]
-    
+
     In [4]: lbview = rc.load_balanced_view()
 
 Apply
@@ -75,7 +75,7 @@ is no longer a string of Python code, but rather a Python function.
 * remote References
 
 The flags for execution have also changed.  Previously, there was only `block` denoting whether
-to wait for results.  This remains, but due to the addition of fully non-copying sends of 
+to wait for results.  This remains, but due to the addition of fully non-copying sends of
 arrays and buffers, there is also a `track` flag, which instructs PyZMQ to produce a :class:`MessageTracker` that will let you know when it is safe again to edit arrays in-place.
 
 The result of a non-blocking call to `apply` is now an :doc:`AsyncResult object <asyncresult>`.
@@ -94,14 +94,14 @@ methods all behave in much the same way as they did on a MultiEngineClient.
 
     # old
     In [2]: mec.execute('a=5', targets=[0,1,2])
-    
+
     # new
     In [2]: view.execute('a=5', targets=[0,1,2])
     # or
     In [2]: rc[0,1,2].execute('a=5')
-    
 
-This extends to any method that communicates with the engines. 
+
+This extends to any method that communicates with the engines.
 
 Requests of the Hub (queue status, etc.) are no-longer asynchronous, and do not take a `block`
 argument.
@@ -115,12 +115,12 @@ argument.
 
     dview.apply(lambda : globals().keys())
 
-* :meth:`push_function` and :meth:`push_serialized` are removed, as :meth:`push` handles 
+* :meth:`push_function` and :meth:`push_serialized` are removed, as :meth:`push` handles
   functions without issue.
- 
+
 .. seealso::
 
-    :ref:`Our Direct Interface doc <parallel_multiengine>` for a simple tutorial with the 
+    :ref:`Our Direct Interface doc <parallel_multiengine>` for a simple tutorial with the
     DirectView.
 
 
@@ -142,7 +142,7 @@ The load-balanced interface is provided by the :class:`LoadBalancedView` class, 
 .. sourcecode:: ipython
 
     In [10]: lbview = rc.load_balanced_view()
-    
+
     # load-balancing can also be restricted to a subset of engines:
     In [10]: lbview = rc.load_balanced_view([1,2,3])
 
@@ -163,11 +163,11 @@ engine, and another resides on the client.  You might construct a task that look
                 push=dict(B=B),
                 pull='C'
                 )
-    
+
     In [11]: tid = tc.run(st)
-    
+
     In [12]: tr = tc.get_task_result(tid)
-    
+
     In [13]: C = tc['C']
 
 In the new code, this is simpler:
@@ -175,11 +175,11 @@ In the new code, this is simpler:
 .. sourcecode:: ipython
 
     In [10]: import numpy
-    
+
     In [11]: from ipyparallel import Reference
-    
+
     In [12]: ar = lbview.apply(numpy.dot, Reference('A'), B)
-    
+
     In [13]: C = ar.get()
 
 Note the use of ``Reference`` This is a convenient representation of an object that exists
@@ -197,7 +197,7 @@ the engine beyond the duration of the task.
 
 .. seealso::
 
-    :ref:`Our Task Interface doc <parallel_task>` for a simple tutorial with the 
+    :ref:`Our Task Interface doc <parallel_task>` for a simple tutorial with the
     LoadBalancedView.
 
 
@@ -241,5 +241,3 @@ result.
 .. seealso::
 
     :doc:`AsyncResult details <asyncresult>`
-
-

--- a/docs/source/winhpc.rst
+++ b/docs/source/winhpc.rst
@@ -78,7 +78,7 @@ IPython on Windows:
 
 * Python 2.6 or 2.7 (http://www.python.org)
 * pywin32 (http://sourceforge.net/projects/pywin32/)
-* PyReadline (https://launchpad.net/pyreadline)
+* PyReadline (https://ipython.org/pyreadline.html)
 * pyzmq (http://github.com/zeromq/pyzmq/downloads)
 * IPython (http://ipython.org)
 


### PR DESCRIPTION
Updated some documentation links that were failing or redirecting in ``make linkcheck``. Added ``winhpc.rst`` to exclude patterns in ``conf.py`` since it is not contained in any toctree and doesn't appear to be used. Leaving it in since others may be linking to the file.

@minrk Let me know if you want me to loop back and undo the removal of the whitespaces on line endings.