### PR TITLE
Fix use_dill() call

### DIFF
--- a/examples/Using Dill.ipynb
+++ b/examples/Using Dill.ipynb
@@ -272,7 +272,7 @@
     "This is equivalent to\n",
     "\n",
     "```python\n",
-    "from ipyparallel.serialize import use_dill\n",
+    "from ipyparallel.canning import use_dill\n",
     "use_dill()\n",
     "rc[:].apply(use_dill)\n",
     "```"

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 
 import zmq
 
-from .. import serialize
+from .. import serialize, canning
 from traitlets import (
     HasTraits, Any, Bool, List, Dict, Set, Instance, CFloat, Integer
 )
@@ -491,18 +491,18 @@ class DirectView(View):
         
         adds support for closures, etc.
         
-        This calls ipyparallel.serialize.use_dill() here and on each engine.
+        This calls ipyparallel.canning.use_dill() here and on each engine.
         """
-        serialize.use_dill()
-        return self.apply(serialize.use_dill)
+        canning.use_dill()
+        return self.apply(canning.use_dill)
 
     def use_cloudpickle(self):
         """Expand serialization support with cloudpickle.
         
-        This calls ipyparallel.serialize.use_cloudpickle() here and on each engine.
+        This calls ipyparallel.canning.use_cloudpickle() here and on each engine.
         """
-        serialize.use_cloudpickle()
-        return self.apply(serialize.use_cloudpickle)
+        canning.use_cloudpickle()
+        return self.apply(canning.use_cloudpickle)
 
 
     @sync_results


### PR DESCRIPTION
The `use_dill()` function is in `ipyparallel.serialize.canning`. Because the ipyparallel `__init__.py` has a line `from serialize import *`, we can (and have to) access canning via `ipyparallel.canning`. This commit fixes calling `use_dill()`. Currently, calling `use_dill()` on a direct view is broken as it tries calling `ipyparallel.serialize.use_dill()`, which is not defined. This commit fixes that, and also updates the
documentation accordingly.