### PR TITLE
add Client.become_distributed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install -f travis-wheels/wheelhouse . coveralls
+    - pip install -f travis-wheels/wheelhouse . distributed coveralls
 script:
     - iptest --coverage xml ipyparallel.tests -- -vsx
 after_success:

--- a/examples/distributed.ipynb
+++ b/examples/distributed.ipynb
@@ -21,7 +21,7 @@
     {
      "data": {
       "text/plain": [
-       "[0, 1, 2, 3, 4, 5, 6, 7]"
+       "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]"
       ]
      },
      "execution_count": 1,
@@ -46,16 +46,27 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "rc.stop_distributed()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Executor: scheduler=172.16.3.46:63868 workers=8 threads=8>"
+       "<Executor: scheduler=172.17.0.2:39898 workers=12 threads=12>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -84,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -106,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -117,13 +128,417 @@
        "-332833500"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "total.result()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I could also let distributed do its multithreading thing, and run one multi-threaded Worker per engine.\n",
+    "\n",
+    "First, I need to get a mapping of one engine per host:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{0: 'c1f0e6865bd0',\n",
+       " 1: 'c1f0e6865bd0',\n",
+       " 2: 'c1f0e6865bd0',\n",
+       " 3: 'c1f0e6865bd0',\n",
+       " 4: 'b0cd5ef58393',\n",
+       " 5: 'b0cd5ef58393',\n",
+       " 6: 'b0cd5ef58393',\n",
+       " 7: 'b0cd5ef58393',\n",
+       " 8: '5f5fe9720dc2',\n",
+       " 9: '5f5fe9720dc2',\n",
+       " 10: '5f5fe9720dc2',\n",
+       " 11: '5f5fe9720dc2'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import socket\n",
+    "\n",
+    "engine_hosts = rc[:].apply_async(socket.gethostname).get_dict()\n",
+    "engine_hosts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I can reverse this mapping, to get a list of engines on each host:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'5f5fe9720dc2': [8, 9, 10, 11],\n",
+       " 'b0cd5ef58393': [4, 5, 6, 7],\n",
+       " 'c1f0e6865bd0': [0, 1, 2, 3]}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "host_engines = {}\n",
+    "for engine_id, host in engine_hosts.items():\n",
+    "    if host not in host_engines:\n",
+    "        host_engines[host] = []\n",
+    "    host_engines[host].append(engine_id)\n",
+    "\n",
+    "host_engines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now I can get one engine per host:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[4, 8, 0]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "one_engine_per_host = [ engines[0] for engines in host_engines.values()]\n",
+    "one_engine_per_host"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Here's a concise, but more opaque version that does the same thing:*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[7, 11, 3]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "one_engine_per_host = list({host:eid for eid,host in engine_hosts.items()}.values())\n",
+    "one_engine_per_host"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I can now stop the first distributed cluster, and start a new one on just these engines, letting distributed allocate threads:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Executor: scheduler=172.17.0.2:37811 workers=3 threads=12>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rc.stop_distributed()\n",
+    "\n",
+    "executor = rc.become_distributed(one_engine_per_host)\n",
+    "executor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And submit the same tasks again:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "A = executor.map(square, range(100))\n",
+    "B = executor.map(neg, A)\n",
+    "total = executor.submit(sum, B)\n",
+    "progress(total)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Debugging distributed with IPython"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Executor: scheduler=172.17.0.2:50514 workers=3 threads=12>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rc.stop_distributed()\n",
+    "\n",
+    "executor = rc.become_distributed(one_engine_per_host)\n",
+    "executor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's set the %px magics to only run on our one engine per host:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "view = rc[one_engine_per_host]\n",
+    "view.block = True\n",
+    "view.activate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's submit some work that's going to fail somewhere in the middle:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "ZeroDivisionError",
+     "evalue": "division by zero",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-14-183a85878b6a>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m     13\u001b[0m \u001b[0mtotal\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mexecutor\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msubmit\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msum\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0minverted\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     14\u001b[0m \u001b[0mdisplay\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mprogress\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtotal\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 15\u001b[1;33m \u001b[0mtotal\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m/opt/conda/lib/python3.4/site-packages/distributed/executor.py\u001b[0m in \u001b[0;36mresult\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     94\u001b[0m         \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msync\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexecutor\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mloop\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_result\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mraiseit\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     95\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstatus\u001b[0m \u001b[1;33m==\u001b[0m \u001b[1;34m'error'\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 96\u001b[1;33m             \u001b[0msix\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mreraise\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     97\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstatus\u001b[0m \u001b[1;33m==\u001b[0m \u001b[1;34m'cancelled'\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     98\u001b[0m             \u001b[1;32mraise\u001b[0m \u001b[0mresult\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/opt/conda/lib/python3.4/site-packages/six.py\u001b[0m in \u001b[0;36mreraise\u001b[1;34m(tp, value, tb)\u001b[0m\n\u001b[0;32m    683\u001b[0m             \u001b[0mvalue\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mtp\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    684\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__traceback__\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mtb\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 685\u001b[1;33m             \u001b[1;32mraise\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwith_traceback\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtb\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    686\u001b[0m         \u001b[1;32mraise\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    687\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/opt/conda/lib/python3.4/site-packages/tornado/concurrent.py\u001b[0m in \u001b[0;36mresult\u001b[1;34m()\u001b[0m\n\u001b[0;32m    230\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_result\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    231\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_exc_info\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 232\u001b[1;33m             \u001b[0mraise_exc_info\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_exc_info\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    233\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_check_done\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    234\u001b[0m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_result\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/opt/conda/lib/python3.4/site-packages/tornado/util.py\u001b[0m in \u001b[0;36mraise_exc_info\u001b[1;34m()\u001b[0m\n",
+      "\u001b[1;32m/opt/conda/lib/python3.4/concurrent/futures/thread.py\u001b[0m in \u001b[0;36mrun\u001b[1;34m()\u001b[0m\n\u001b[0;32m     52\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     53\u001b[0m         \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 54\u001b[1;33m             \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfn\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     55\u001b[0m         \u001b[1;32mexcept\u001b[0m \u001b[0mBaseException\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     56\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfuture\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mset_exception\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0me\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m<ipython-input-14-183a85878b6a>\u001b[0m in \u001b[0;36minverse\u001b[1;34m()\u001b[0m\n\u001b[0;32m      6\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      7\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0minverse\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 8\u001b[1;33m     \u001b[1;32mreturn\u001b[0m \u001b[1;36m1\u001b[0m \u001b[1;33m/\u001b[0m \u001b[0mx\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      9\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     10\u001b[0m \u001b[0mshifted\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mexecutor\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmap\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mshift5\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mrange\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;36m10\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mZeroDivisionError\u001b[0m: division by zero"
+     ]
+    }
+   ],
+   "source": [
+    "from IPython.display import display\n",
+    "from distributed import progress\n",
+    "\n",
+    "def shift5(x):\n",
+    "    return x - 5\n",
+    "\n",
+    "def inverse(x):\n",
+    "    return 1 / x\n",
+    "\n",
+    "shifted = executor.map(shift5, range(1, 10))\n",
+    "inverted = executor.map(inverse, shifted)\n",
+    "                       \n",
+    "total = executor.submit(sum, inverted)\n",
+    "display(progress(total))\n",
+    "total.result()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see which task failed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Future: status: error, key: inverse-bc7b7ed8f481797d9d45265f252f8ec0>]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[ f for f in inverted if f.status == 'error' ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When IPython starts a worker on each engine,\n",
+    "it stores it in the `distributed_worker` variable in the engine's namespace.\n",
+    "This lets us query the worker interactively.\n",
+    "\n",
+    "We can check out the current data resident on each worker:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mOut[7:8]: \u001b[0m\n",
+       "{'inverse-d6e0e00cb3347936f19e9df3d38015f4': 0.3333333333333333,\n",
+       " 'shift5-5eacd1e1be0e3976b644ab2a163dd111': 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mOut[11:8]: \u001b[0m\n",
+       "{'inverse-10c0d2c106d28ef201f314c962839478': -1.0,\n",
+       " 'inverse-6f68a726ebadebb024c30716b0ddbb33': -0.25,\n",
+       " 'inverse-a354f18c105e23ca2dc069587b14a5b8': 0.5,\n",
+       " 'shift5-3712885ebc1366e919cb866c6ce7e77c': -1,\n",
+       " 'shift5-4786df703d91632633e692bfcb47532e': -4,\n",
+       " 'shift5-a427120073a9ba8d2916dc408ec401c4': 0,\n",
+       " 'shift5-da44bc9d4f586c6a49b0d5822143e2a4': 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mOut[3:8]: \u001b[0m\n",
+       "{'inverse-59a0bf9ebd0226fb90bc0a5df5068b9f': 0.25,\n",
+       " 'inverse-65ef68148fccac8c4b06be72b955729a': -0.5,\n",
+       " 'inverse-6dda39073ba4c48681553145497ff0ad': 1.0,\n",
+       " 'inverse-8990646f88d288c4fbdb3b0be2017cf8': -0.3333333333333333,\n",
+       " 'shift5-17492f2a64f68132ebc986319e5dc9c3': 4,\n",
+       " 'shift5-5dbf6e302e056087bd8a55aa5ec44932': -2,\n",
+       " 'shift5-b0c68352cec6649a8b25dd9dded3679e': 1,\n",
+       " 'shift5-daecbbabc904f01ce981587adf933318': -3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "distributed_worker.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Now that we can poke around with each Worker,\n",
+    "we can have a slightly easier time figuring out what went wrong."
    ]
   }
  ],
@@ -143,7 +558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.0"
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,

--- a/examples/distributed.ipynb
+++ b/examples/distributed.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with distributed\n",
+    "\n",
+    "[Distributed](https://distributed.readthedocs.org) is a cool library for doing distributed execution. You should check it out, if you haven't already.\n",
+    "\n",
+    "Assuming you already have an IPython cluster running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 1, 2, 3, 4, 5, 6, 7]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import ipyparallel as ipp\n",
+    "rc = ipp.Client()\n",
+    "rc.ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can turn your IPython cluster into a distributed cluster by calling `Client.become_distributed()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Executor: scheduler=172.16.3.46:63868 workers=8 threads=8>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "executor = rc.become_distributed(ncores=1)\n",
+    "executor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will:\n",
+    "\n",
+    "1. start a Scheduler on the Hub\n",
+    "2. start a Worker on each engine\n",
+    "3. return an Executor, the distributed client API\n",
+    "\n",
+    "By default, distributed Workers will use threads to run on all cores of a machine. \n",
+    "In this case, since I already have one *engine* per core,\n",
+    "I tell distributed to run one core per Worker with `ncores=1`.\n",
+    "\n",
+    "We can now use our IPython cluster with distributed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from distributed import progress\n",
+    "\n",
+    "def square(x):\n",
+    "    return x ** 2\n",
+    "\n",
+    "def neg(x):\n",
+    "        return -x\n",
+    "\n",
+    "A = executor.map(square, range(1000))\n",
+    "B = executor.map(neg, A)\n",
+    "total = executor.submit(sum, B)\n",
+    "progress(total)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-332833500"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "total.result()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1262,7 +1262,7 @@ class Client(HasTraits):
         if error:
             raise error
 
-    def become_distributed(self, targets='all', port=0, scheduler_args=None, worker_args=None):
+    def become_distributed(self, targets='all', port=0, scheduler_args=None, **worker_args):
         """Turn the IPython cluster into a dask.distributed cluster
 
         Parameters
@@ -1273,9 +1273,9 @@ class Client(HasTraits):
         port: int (default: random)
             Which port
         scheduler_args: dict
-            Additional keyword arguments (e.g. ip) are passed to the distributed.Scheduler constructor.
-        worker_args: dict
-            Additional keyword arguments (e.g. threads) are passed to the distributed.Worker constructor.
+            Keyword arguments (e.g. ip) to pass to the distributed.Scheduler constructor.
+        **worker_args:
+            Any additional keyword arguments (e.g. ncores) are passed to the distributed.Worker constructor.
 
         Returns
         -------
@@ -1291,10 +1291,6 @@ class Client(HasTraits):
             scheduler_args = {}
         else:
             scheduler_args = dict(scheduler_args) # copy
-        if worker_args is None:
-            worker_args = {}
-        else:
-            worker_args = dict(worker_args) # copy
 
         # Start a Scheduler on the Hub:
         reply = self._send_recv(self._query_socket, 'become_distributed_request')

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1313,6 +1313,25 @@ class Client(HasTraits):
         executor = distributed.Executor('{ip}:{port}'.format(**distributed_info))
         return executor
 
+    def stop_distributed(self, targets='all'):
+        """Stop the distributed Scheduler and Workers started by become_distributed.
+
+        Parameters
+        ----------
+
+        targets: target spec (default: all)
+            Which engines to turn into distributed workers.
+        """
+        dview = self.direct_view(targets)
+
+        # Start a Scheduler on the Hub:
+        reply = self._send_recv(self._query_socket, 'stop_distributed_request')
+        if reply['content']['status'] != 'ok':
+            raise self._unwrap_exception(reply['content'])
+
+        # Finally, stop all the Workers on the engines
+        dview.apply_sync(util.stop_distributed_worker)
+
     #--------------------------------------------------------------------------
     # Execution related methods
     #--------------------------------------------------------------------------

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1262,7 +1262,7 @@ class Client(HasTraits):
         if error:
             raise error
 
-    def become_distributed(self, targets='all', port=0, scheduler_args=None, **worker_args):
+    def become_distributed(self, targets='all', port=0, nanny=False, scheduler_args=None, **worker_args):
         """Turn the IPython cluster into a dask.distributed cluster
 
         Parameters
@@ -1272,6 +1272,9 @@ class Client(HasTraits):
             Which engines to turn into distributed workers.
         port: int (default: random)
             Which port
+        nanny: bool (default: False)
+            Whether to start workers as subprocesses instead of in the engine process.
+            Using a nanny allows restarting the worker processes via ``executor.restart``.
         scheduler_args: dict
             Keyword arguments (e.g. ip) to pass to the distributed.Scheduler constructor.
         **worker_args:
@@ -1299,9 +1302,9 @@ class Client(HasTraits):
         distributed_info = reply['content']
 
         # Start a Worker on the selected engines:
-        dview = self.direct_view(targets)
         worker_args['ip'] = distributed_info['ip']
         worker_args['port'] = distributed_info['port']
+        worker_args['nanny'] = nanny
 
         # Finally, return an Executor connected to the Scheduler
         dview.apply_sync(util.become_distributed_worker, **worker_args)

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1296,7 +1296,9 @@ class Client(HasTraits):
             scheduler_args = dict(scheduler_args) # copy
 
         # Start a Scheduler on the Hub:
-        reply = self._send_recv(self._query_socket, 'become_distributed_request')
+        reply = self._send_recv(self._query_socket, 'become_distributed_request',
+            {'scheduler_args': scheduler_args},
+        )
         if reply['content']['status'] != 'ok':
             raise self._unwrap_exception(reply['content'])
         distributed_info = reply['content']

--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -441,6 +441,7 @@ class Hub(SessionFactory):
                                 'unregistration_request' : self.unregister_engine,
                                 'connection_request': self.connection_request,
                                 'become_distributed_request': self.become_distributed,
+                                'stop_distributed_request': self.stop_distributed,
         }
 
         # ignore resubmit replies
@@ -1460,6 +1461,20 @@ class Hub(SessionFactory):
         }
         self.log.info("dask.distributed scheduler running at {ip}:{port}".format(**content))
         self.session.send(self.query, "become_distributed_reply", content=content,
+            parent=msg, ident=client_id,
+        )
+
+
+    def stop_distributed(self, client_id, msg):
+        """Start a dask.distributed Scheduler."""
+        if self.distributed_scheduler is not None:
+            self.log.info("Stopping dask.distributed scheduler")
+            self.distributed_scheduler.close()
+            self.distributed_scheduler = None
+        else:
+            self.log.info("No dask.distributed scheduler running.")
+        content = {'status': 'ok'}
+        self.session.send(self.query, "stop_distributed_reply", content=content,
             parent=msg, ident=client_id,
         )
 

--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -1446,9 +1446,9 @@ class Hub(SessionFactory):
     def become_distributed(self, client_id, msg):
         """Start a dask.distributed Scheduler."""
         if self.distributed_scheduler is None:
-            self.log.info("Becoming dask.distributed scheduler")
+            kwargs = msg['content'].get('scheduler_args', {})
+            self.log.info("Becoming dask.distributed scheduler: %s", kwargs)
             from distributed import Scheduler
-            kwargs = msg['content'].get('scheduler_kwargs', {})
             port = msg['content'].get('port', 0)
             kwargs['loop'] = self.loop
             self.distributed_scheduler = scheduler = Scheduler(**kwargs)

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -403,7 +403,7 @@ def int_keys(dikt):
     return dikt
 
 
-def become_distributed_worker(ip, port, **kwargs):
+def become_distributed_worker(ip, port, nanny=False, **kwargs):
     """Task function for becoming a distributed Worker
 
     Parameters
@@ -419,10 +419,13 @@ def become_distributed_worker(ip, port, **kwargs):
     shell = get_ipython()
     kernel = shell.kernel
     if getattr(kernel, 'distributed_worker', None) is not None:
-        kernel.log.info("Distributed worker already running")
+        kernel.log.info("Distributed worker is already running.")
         return
-    from distributed import Worker
-    w = Worker(ip, port, **kwargs)
+    from distributed import Worker, Nanny
+    if nanny:
+        w = Nanny(ip, port, **kwargs)
+    else:
+        w = Worker(ip, port, **kwargs)
     shell.user_ns['distributed_worker'] = kernel.distributed_worker = w
     w.start(0)
 


### PR DESCRIPTION
Turns current IPython cluster into a [distributed](https://distributed.readthedocs.org) cluster:

- starts Scheduler on the Hub
- starts Worker on each engine
- returns Executor connected to the Scheduler

This was super easy, thanks @mrocklin!

Questions for @mrocklin:

- Should there be different default args to the constructor(s)?
- Is the worker or scheduler more likely to get non-default constructor args?
- Anything else to consider?