### PR TITLE
Add joblib backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
+    - pip install https://github.com/joblib/joblib/archive/master.zip # while joblib 0.10 isn't out
     - pip install -f travis-wheels/wheelhouse . distributed coveralls
 script:
     - iptest --coverage xml ipyparallel.tests -- -vsx

--- a/examples/joblib.ipynb
+++ b/examples/joblib.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using IPython Parallel as a joblib backend\n",
+    "\n",
+    "joblib 0.10 adds the ability to register a custom parallel backend.\n",
+    "IPython 5.1 defines one such backend, so you can use IPython parallel with joblib.\n",
+    "\n",
+    "The simplest way to set this up is a single import:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import ipyparallel.joblib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This registers the 'ipyparallel' backend with all the defaults."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0,\n",
+       " -1,\n",
+       " -2,\n",
+       " -3,\n",
+       " -4,\n",
+       " -5,\n",
+       " -6,\n",
+       " -7,\n",
+       " -8,\n",
+       " -9,\n",
+       " -10,\n",
+       " -11,\n",
+       " -12,\n",
+       " -13,\n",
+       " -14,\n",
+       " -15,\n",
+       " -16,\n",
+       " -17,\n",
+       " -18,\n",
+       " -19,\n",
+       " -20,\n",
+       " -21,\n",
+       " -22,\n",
+       " -23,\n",
+       " -24,\n",
+       " -25,\n",
+       " -26,\n",
+       " -27,\n",
+       " -28,\n",
+       " -29,\n",
+       " -30,\n",
+       " -31]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from joblib import Parallel, delayed\n",
+    "\n",
+    "def neg(x):\n",
+    "    return -x\n",
+    "\n",
+    "Parallel(backend='ipyparallel')(delayed(neg)(i) for i in range(32))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also configure your own View, and register it explicitly, or even as the default:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import ipyparallel as ipp\n",
+    "rc = ipp.Client()\n",
+    "rc[:].use_cloudpickle()\n",
+    "view = rc.load_balanced_view()\n",
+    "view.register_joblib_backend(make_default=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[10625, 10621, 10647, 10637, 10622, 10620, 10642, 10631, 10625, 10621]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "Parallel()(delayed(os.getpid)() for i in range(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Joblib also provides a context manager for selecting a particular backend:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[10622, 10620, 10642, 10631, 10622]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "even = rc.load_balanced_view(targets=rc.ids[::2])\n",
+    "even.register_joblib_backend('even')\n",
+    "\n",
+    "from joblib import parallel_backend\n",
+    "with parallel_backend('even'):\n",
+    "    result = Parallel()(delayed(os.getpid)() for i in range(5))\n",
+    "result"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/joblib.ipynb
+++ b/examples/joblib.ipynb
@@ -9,7 +9,7 @@
     "joblib 0.10 adds the ability to register a custom parallel backend.\n",
     "IPython 5.1 defines one such backend, so you can use IPython parallel with joblib.\n",
     "\n",
-    "The simplest way to set this up is a single import:"
+    "The simplest way to set this up is a single call:"
    ]
   },
   {
@@ -20,7 +20,8 @@
    },
    "outputs": [],
    "source": [
-    "import ipyparallel.joblib"
+    "import ipyparallel as ipp\n",
+    "ipp.register_joblib_backend()"
    ]
   },
   {

--- a/ipyparallel/__init__.py
+++ b/ipyparallel/__init__.py
@@ -50,8 +50,13 @@ def bind_kernel(**kwargs):
             pass
         else:
             return app.bind_kernel(**kwargs)
-    
+
     raise RuntimeError("bind_kernel be called from an IPEngineApp instance")
-    
+
+
+def register_joblib_backend(name='ipyparallel', make_default=False):
+    """Register the default ipyparallel backend for joblib."""
+    from .joblib import register
+    return register(name=name, make_default=make_default)
 
 

--- a/ipyparallel/client/_joblib.py
+++ b/ipyparallel/client/_joblib.py
@@ -1,0 +1,63 @@
+"""joblib parallel backend for IPython Parallel"""
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import absolute_import
+
+import ipyparallel as ipp
+from joblib._parallel_backends import ParallelBackendBase, AutoBatchingMixin
+
+class IPythonParallelBackend(AutoBatchingMixin, ParallelBackendBase):
+
+    def __init__(self, view=None):
+        if view is None:
+            self._owner = True
+            rc = ipp.Client()
+            view = rc.load_balanced_view()
+            # use cloudpickle or dill for closures, if available.
+            # joblib tends to create closured default pickle can't handle.
+            try:
+                import cloudpickle
+            except ImportError:
+                try:
+                    import dill
+                except ImportError:
+                    pass
+                else:
+                    view.client[:].use_dill()
+            else:
+                view.client[:].use_cloudpickle()
+        else:
+            self._owner = False
+        self._view = view
+
+    def effective_n_jobs(self, n_jobs):
+        """Determine the number of jobs that can actually run in parallel.
+        n_jobs is the is the number of workers requested by the callers.
+        Passing n_jobs=-1 means requesting all available workers for instance
+        matching the number of CPU cores on the worker host(s).
+        This method should return a guesstimate of the number of workers that
+        can actually perform work concurrently. The primary use case is to make
+        it possible for the caller to know in how many chunks to slice the
+        work.
+        In general working on larger data chunks is more efficient (less
+        scheduling overhead and better use of CPU cache prefetching heuristics)
+        as long as all the workers have enough work to do.
+        """
+        if n_jobs == -1:
+            return len(self._view)
+        return min(len(self._view), n_jobs)
+
+    def terminate(self):
+        """Close the client if we created it"""
+        if self._owner:
+            self._view.client.close()
+
+    def apply_async(self, func, callback=None):
+        """Schedule a func to be run"""
+        future = self._view.apply_async(func)
+        if callback:
+            future.add_done_callback(lambda f: callback(f.result()))
+        return future
+
+

--- a/ipyparallel/client/_joblib.py
+++ b/ipyparallel/client/_joblib.py
@@ -32,21 +32,8 @@ class IPythonParallelBackend(AutoBatchingMixin, ParallelBackendBase):
         self._view = view
 
     def effective_n_jobs(self, n_jobs):
-        """Determine the number of jobs that can actually run in parallel.
-        n_jobs is the is the number of workers requested by the callers.
-        Passing n_jobs=-1 means requesting all available workers for instance
-        matching the number of CPU cores on the worker host(s).
-        This method should return a guesstimate of the number of workers that
-        can actually perform work concurrently. The primary use case is to make
-        it possible for the caller to know in how many chunks to slice the
-        work.
-        In general working on larger data chunks is more efficient (less
-        scheduling overhead and better use of CPU cache prefetching heuristics)
-        as long as all the workers have enough work to do.
-        """
-        if n_jobs == -1:
-            return len(self._view)
-        return min(len(self._view), n_jobs)
+        """A View can run len(view) jobs at a time"""
+        return len(self._view)
 
     def terminate(self):
         """Close the client if we created it"""

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -3,7 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import imp
 import warnings
@@ -1099,6 +1099,28 @@ class LoadBalancedView(View):
 
         pf = ParallelFunction(self, f, block=block, chunksize=chunksize, ordered=ordered)
         return pf.map(*sequences)
+
+    def register_joblib_backend(self, name='ipyparallel', make_default=False):
+        """Register this View as a joblib parallel backend
+
+        To make this the default backend, set make_default=True.
+
+        Use with::
+
+            p = Parallel(backend='ipyparallel')
+            ...
+
+        See joblib docs for details
+
+        Requires joblib >= 0.10
+
+        .. versionadded:: 5.1
+        """
+        from joblib.parallel import register_parallel_backend
+        from ._joblib import IPythonParallelBackend
+        register_parallel_backend(name,
+            lambda : IPythonParallelBackend(view=self),
+            make_default=make_default)
 
 from concurrent.futures import Executor
 

--- a/ipyparallel/joblib.py
+++ b/ipyparallel/joblib.py
@@ -1,0 +1,34 @@
+"""IPython parallel backend for joblib
+
+To enable the default view as a backend for joblib::
+
+    import ipyparallel.joblib
+
+Or to enable a particular View you have already set up::
+
+    view.register_joblib_backend()
+
+At this point, you can use it with::
+
+    with parallel_backend('ipyparallel'):
+        Parallel(n_jobs=2)(delayed(some_function)(i) for i in range(10))
+
+.. versionadded:: 5.1
+"""
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import absolute_import
+
+from joblib.parallel import register_parallel_backend
+from .client._joblib import IPythonParallelBackend
+
+def register(name='ipyparallel', make_default=False):
+    """Register the default ipyparallel Client as a joblib backend
+    
+    See joblib.parallel.register_parallel_backend for details.
+    """
+    return register_parallel_backend(name, IPythonParallelBackend, make_default=make_default)
+
+# importing ipyparallel.joblib sets up the default `ipyparallel` backend
+register()

--- a/ipyparallel/joblib.py
+++ b/ipyparallel/joblib.py
@@ -2,7 +2,8 @@
 
 To enable the default view as a backend for joblib::
 
-    import ipyparallel.joblib
+    import ipyparallel as ipp
+    ipp.register_joblib_backend()
 
 Or to enable a particular View you have already set up::
 
@@ -29,6 +30,3 @@ def register(name='ipyparallel', make_default=False):
     See joblib.parallel.register_parallel_backend for details.
     """
     return register_parallel_backend(name, IPythonParallelBackend, make_default=make_default)
-
-# importing ipyparallel.joblib sets up the default `ipyparallel` backend
-register()

--- a/ipyparallel/tests/test_joblib.py
+++ b/ipyparallel/tests/test_joblib.py
@@ -33,6 +33,16 @@ class TestJobLib(ClusterTestCase):
         with mock.patch('ipyparallel.Client', lambda : self.client):
             p = Parallel(backend='ipyparallel')
             assert p._backend._view.client is self.client
+        
+        # FIXME: add View.use_pickle to undo use_cloudpickle
+        def _restore_default_pickle():
+            import pickle
+            from ipyparallel.serialize import canning, serialize
+            canning.pickle = serialize.pickle = pickle
+            canning.can_map[canning.FunctionType] = canning.CannedFunction
+        
+        _restore_default_pickle()
+        self.client[:].apply_sync(_restore_default_pickle)
     
     def test_register_backend(self):
         view = self.client.load_balanced_view()

--- a/ipyparallel/tests/test_joblib.py
+++ b/ipyparallel/tests/test_joblib.py
@@ -1,10 +1,9 @@
 
 from nose import SkipTest
 
-from ipyparallel.client import client as clientmod
-from ipyparallel import error, AsyncHubResult, DirectView, Reference
-
-from .clienttest import ClusterTestCase, wait, add_engines, skip_without
+# from ipyparallel import error, AsyncHubResult, DirectView, Reference
+import ipyparallel as ipp
+from .clienttest import ClusterTestCase
 
 try:
     import joblib
@@ -27,7 +26,7 @@ class TestJobLib(ClusterTestCase):
     
     def test_import_joblib_registers(self):
         """import ipyparallel.joblib registers backend"""
-        import ipyparallel.joblib
+        ipp.register_joblib_backend()
         p = Parallel(backend='ipyparallel')
         self.assertIs(p.backend_factory, IPythonParallelBackend)
     

--- a/ipyparallel/tests/test_joblib.py
+++ b/ipyparallel/tests/test_joblib.py
@@ -1,0 +1,45 @@
+
+from nose import SkipTest
+
+from ipyparallel.client import client as clientmod
+from ipyparallel import error, AsyncHubResult, DirectView, Reference
+
+from .clienttest import ClusterTestCase, wait, add_engines, skip_without
+
+try:
+    import joblib
+    from joblib import Parallel, delayed
+    from ipyparallel.client._joblib import IPythonParallelBackend
+    
+except ImportError:
+    have_joblib = False
+else:
+    have_joblib = True
+
+def neg(x):
+    return -1 * x
+
+class TestJobLib(ClusterTestCase):
+    def setUp(self):
+        if not have_joblib:
+            raise SkipTest("Requires joblib >= 0.10")
+        super(TestJobLib, self).setUp()
+    
+    def test_import_joblib_registers(self):
+        """import ipyparallel.joblib registers backend"""
+        import ipyparallel.joblib
+        p = Parallel(backend='ipyparallel')
+        self.assertIs(p.backend_factory, IPythonParallelBackend)
+    
+    def test_register_backend(self):
+        view = self.client.load_balanced_view()
+        view.register_joblib_backend('view')
+        p = Parallel(backend='view')
+        self.assertIs(p.backend_factory()._view, view)
+
+    def test_joblib_backend(self):
+        view = self.client.load_balanced_view()
+        view.register_joblib_backend('view')
+        p = Parallel(backend='view')
+        result = p(delayed(neg)(i) for i in range(10))
+        self.assertEqual(result, [neg(i) for i in range(10)])

--- a/ipyparallel/tests/test_joblib.py
+++ b/ipyparallel/tests/test_joblib.py
@@ -1,15 +1,17 @@
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from nose import SkipTest
 
-# from ipyparallel import error, AsyncHubResult, DirectView, Reference
 import ipyparallel as ipp
-from .clienttest import ClusterTestCase
+from .clienttest import ClusterTestCase, add_engines
 
 try:
     import joblib
     from joblib import Parallel, delayed
     from ipyparallel.client._joblib import IPythonParallelBackend
-    
 except ImportError:
     have_joblib = False
 else:
@@ -23,18 +25,20 @@ class TestJobLib(ClusterTestCase):
         if not have_joblib:
             raise SkipTest("Requires joblib >= 0.10")
         super(TestJobLib, self).setUp()
-    
-    def test_import_joblib_registers(self):
-        """import ipyparallel.joblib registers backend"""
+        add_engines(1, total=True)
+
+    def test_default_backend(self):
+        """ipyparallel.register_joblib_backend() registers default backend"""
         ipp.register_joblib_backend()
-        p = Parallel(backend='ipyparallel')
-        self.assertIs(p.backend_factory, IPythonParallelBackend)
+        with mock.patch('ipyparallel.Client', lambda : self.client):
+            p = Parallel(backend='ipyparallel')
+            assert p._backend._view.client is self.client
     
     def test_register_backend(self):
         view = self.client.load_balanced_view()
         view.register_joblib_backend('view')
         p = Parallel(backend='view')
-        self.assertIs(p.backend_factory()._view, view)
+        self.assertIs(p._backend._view, view)
 
     def test_joblib_backend(self):
         view = self.client.load_balanced_view()

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ extras_require = setuptools_args['extras_require'] = {
 
 tests_require = setuptools_args['tests_require'] = [
     'nose',
+    'ipython[test]',
 ]
 
 if 'setuptools' in sys.modules:

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ extras_require = setuptools_args['extras_require'] = {
 tests_require = setuptools_args['tests_require'] = [
     'nose',
     'ipython[test]',
+    'mock',
 ]
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
In https://github.com/joblib/joblib/pull/306, joblib adds support for custom backends.

This provides such a backend from a LoadBalancedView.

Simplest version using all the defaults:

    import ipyparallel.backend

Or registering an existing View:

    view.register_joblib_backend([name])