### PR TITLE
add View.use_pickle()

### DIFF
--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -502,6 +502,14 @@ class DirectView(View):
         serialize.use_cloudpickle()
         return self.apply(serialize.use_cloudpickle)
 
+    def use_pickle(self):
+        """Restore
+        
+        This reverts changes to serialization caused by `use_dill|.cloudpickle`.
+        """
+        serialize.use_pickle()
+        return self.apply(serialize.use_pickle)
+
 
     @sync_results
     @save_ids

--- a/ipyparallel/serialize/__init__.py
+++ b/ipyparallel/serialize/__init__.py
@@ -1,6 +1,6 @@
 from .canning import (
     Reference, can_map, uncan_map, can, uncan,
-    use_dill, use_cloudpickle,
+    use_dill, use_cloudpickle, use_pickle,
 )
 from .serialize import (
     serialize_object, deserialize_object,
@@ -15,6 +15,7 @@ __all__ = (
     'uncan',
     'use_dill',
     'use_cloudpickle',
+    'use_pickle',
     'serialize_object',
     'deserialize_object',
     'pack_apply_message',

--- a/ipyparallel/serialize/serialize.py
+++ b/ipyparallel/serialize/serialize.py
@@ -9,13 +9,19 @@ try:
 except:
     cPickle = None
     import pickle
+_stdlib_pickle = pickle
+
+try:
+    PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL
+except AttributeError:
+    PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
 
 from itertools import chain
 
 from ipython_genutils.py3compat import PY3, buffer_to_bytes_py2
 from .canning import (
     can, uncan, can_sequence, uncan_sequence, CannedObject,
-    istype, sequence_types, PICKLE_PROTOCOL,
+    istype, sequence_types,
 )
 from jupyter_client.session import MAX_ITEMS, MAX_BYTES
 

--- a/ipyparallel/tests/test_joblib.py
+++ b/ipyparallel/tests/test_joblib.py
@@ -34,15 +34,7 @@ class TestJobLib(ClusterTestCase):
             p = Parallel(backend='ipyparallel')
             assert p._backend._view.client is self.client
         
-        # FIXME: add View.use_pickle to undo use_cloudpickle
-        def _restore_default_pickle():
-            import pickle
-            from ipyparallel.serialize import canning, serialize
-            canning.pickle = serialize.pickle = pickle
-            canning.can_map[canning.FunctionType] = canning.CannedFunction
-        
-        _restore_default_pickle()
-        self.client[:].apply_sync(_restore_default_pickle)
+        self.client[:].use_pickle()
     
     def test_register_backend(self):
         view = self.client.load_balanced_view()


### PR DESCRIPTION
undoes cloudpickle/dill customization, restoring stdlib pickle

useful for testing/resetting context