### PR TITLE
Added 'slurm' ipcluster launch commands

### DIFF
--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -39,7 +39,7 @@ _description = """Start an IPython cluster for parallel computing.
 An IPython cluster consists of 1 controller and 1 or more engines.
 This command automates the startup of these processes using a wide range of
 startup methods (SSH, local processes, PBS, mpiexec, SGE, LSF, HTCondor,
-Windows HPC Server 2008). To start a cluster with 4 engines on your
+Slurm, Windows HPC Server 2008). To start a cluster with 4 engines on your
 local host simply do 'ipcluster start --n=4'. For more complex usage
 you will typically do 'ipython profile create mycluster --parallel', then edit
 configuration files, followed by 'ipcluster start --profile=mycluster --n=4'.
@@ -95,7 +95,7 @@ def find_launcher_class(clsname, kind):
     clsname : str
         The full name of the launcher class, either with or without the
         module path, or an abbreviation (MPI, SSH, SGE, PBS, LSF, HTCondor
-        WindowsHPC).
+        Slurm, WindowsHPC).
     kind : str
         Either 'EngineSet' or 'Controller'.
     """
@@ -264,6 +264,7 @@ class IPClusterEngines(BaseParallelApplication):
                         around, so you will likely have to do this manually
                         unless the machines are on a shared file system.
             HTCondor : use HTCondor to submit engines to a batch queue
+            Slurm : use Slurm to submit engines to a batch queue
             WindowsHPC : use Windows HPC
 
         If you are using one of IPython's builtin launchers, you can specify just the
@@ -469,6 +470,7 @@ class IPClusterStart(IPClusterEngines):
             SGE : use SGE (qsub) to submit the controller to a batch queue
             LSF : use LSF (bsub) to submit the controller to a batch queue
             HTCondor : use HTCondor to submit the controller to a batch queue
+            Slurm : use Slurm to submit engines to a batch queue
             SSH : use SSH to start the controller
             WindowsHPC : use Windows HPC
 

--- a/ipyparallel/tests/test_launcher.py
+++ b/ipyparallel/tests/test_launcher.py
@@ -124,6 +124,9 @@ class TestMPIControllerLauncher(ControllerLauncherTest, TestCase):
 class TestPBSControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
     launcher_class = launcher.PBSControllerLauncher
 
+class TestSlurmControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
+    launcher_class = launcher.SlurmControllerLauncher
+
 class TestSGEControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
     launcher_class = launcher.SGEControllerLauncher
 
@@ -152,6 +155,9 @@ class TestMPIEngineSetLauncher(EngineSetLauncherTest, TestCase):
 
 class TestPBSEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
     launcher_class = launcher.PBSEngineSetLauncher
+
+class TestSlurmEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
+    launcher_class = launcher.SlurmEngineSetLauncher
 
 class TestSGEEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
     launcher_class = launcher.SGEEngineSetLauncher


### PR DESCRIPTION
* for https://computing.llnl.gov/linux/slurm/
* renamed _insert_queue_in_script -> _insert_options_in_script
* ex:
    ipcluster start -n64 --ip='*'  --engines=Slurm \
    --SlurmLauncher.account=project --SlurmLauncher.queue=prod