### PR TITLE
use nbytes of memory views to measure size

### DIFF
--- a/ipyparallel/serialize/serialize.py
+++ b/ipyparallel/serialize/serialize.py
@@ -33,13 +33,28 @@ if PY3:
 # Serialization Functions
 #-----------------------------------------------------------------------------
 
+def _nbytes(buf):
+    """Return byte-size of a memoryview or buffer"""
+    if isinstance(buf, memoryview):
+        if PY3:
+            # py3 introduces nbytes attribute
+            return buf.nbytes
+        else:
+            # compute nbytes on py2
+            size = buf.itemsize
+            for dim in buf.shape:
+                size *= dim
+            return size
+    else:
+        # not a memoryview, raw bytes/ py2 buffer
+        return len(buf)
 
 def _extract_buffers(obj, threshold=MAX_BYTES):
     """extract buffers larger than a certain threshold"""
     buffers = []
     if isinstance(obj, CannedObject) and obj.buffers:
-        for i,buf in enumerate(obj.buffers):
-            nbytes = buf.nbytes if isinstance(buf, memoryview) else len(buf)
+        for i, buf in enumerate(obj.buffers):
+            nbytes = _nbytes(buf)
             if nbytes > threshold:
                 # buffer larger than threshold, prevent pickling
                 obj.buffers[i] = None

--- a/ipyparallel/serialize/serialize.py
+++ b/ipyparallel/serialize/serialize.py
@@ -39,7 +39,8 @@ def _extract_buffers(obj, threshold=MAX_BYTES):
     buffers = []
     if isinstance(obj, CannedObject) and obj.buffers:
         for i,buf in enumerate(obj.buffers):
-            if len(buf) > threshold:
+            nbytes = buf.nbytes if isinstance(buf, memoryview) else len(buf)
+            if nbytes > threshold:
                 # buffer larger than threshold, prevent pickling
                 obj.buffers[i] = None
                 buffers.append(buf)

--- a/ipyparallel/tests/test_canning.py
+++ b/ipyparallel/tests/test_canning.py
@@ -1,0 +1,67 @@
+
+import os
+import pickle
+
+import nose.tools as nt
+from ipyparallel.serialize.canning import can, uncan
+
+def interactive(f):
+    f.__module__ = '__main__'
+    return f
+
+def dumps(obj):
+    return pickle.dumps(can(obj))
+
+def loads(obj):
+    return uncan(pickle.loads(obj))
+
+def test_no_closure():
+    @interactive
+    def foo():
+        a = 5
+        return a
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+def test_generator_closure():
+    # this only creates a closure on Python 3
+    @interactive
+    def foo():
+        i = 'i'
+        r = [ i for j in (1,2) ]
+        return r
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+def test_nested_closure():
+    @interactive
+    def foo():
+        i = 'i'
+        def g():
+            return i
+        return g()
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+def test_closure():
+    i = 'i'
+    @interactive
+    def foo():
+        return i
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+def test_uncan_bytes_buffer():
+    data = b'data'
+    canned = can(data)
+    canned.buffers = [memoryview(buf) for buf in canned.buffers]
+    out = uncan(canned)
+    nt.assert_equal(out, data)

--- a/ipyparallel/tests/test_serialize.py
+++ b/ipyparallel/tests/test_serialize.py
@@ -204,3 +204,20 @@ def test_class_inheritance():
     D2 = d['D']
     nt.assert_equal(D2.a, D.a)
     nt.assert_equal(D2.b, D.b)
+
+@dec.skip_without('numpy')
+def test_pickle_threshold():
+    import numpy
+    from numpy.testing.utils import assert_array_equal
+    A = numpy.ones((5, 5))
+    bufs = serialize_object(A, 1024)
+    nt.assert_equal(len(bufs), 1)
+    B, _ = deserialize_object(bufs)
+    assert_array_equal(A, B)
+
+    A = numpy.ones((512, 512))
+    bufs = serialize_object(A, 1024)
+    nt.assert_equal(len(bufs), 2)
+    B, _ = deserialize_object(bufs)
+    assert_array_equal(A, B)
+

--- a/ipyparallel/tests/test_serialize.py
+++ b/ipyparallel/tests/test_serialize.py
@@ -1,0 +1,206 @@
+"""test serialization tools"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pickle
+from collections import namedtuple
+
+import nose.tools as nt
+
+from ipyparallel.serialize import serialize_object, deserialize_object
+from IPython.testing import decorators as dec
+from ipyparallel import interactive
+from ipyparallel.serialize.canning import CannedArray, CannedClass
+
+#-------------------------------------------------------------------------------
+# Globals and Utilities
+#-------------------------------------------------------------------------------
+
+def roundtrip(obj):
+    """roundtrip an object through serialization"""
+    bufs = serialize_object(obj)
+    obj2, remainder = deserialize_object(bufs)
+    nt.assert_equals(remainder, [])
+    return obj2
+
+
+SHAPES = ((100,), (1024,10), (10,8,6,5), (), (0,))
+DTYPES = ('uint8', 'float64', 'int32', [('g', 'float32')], '|S10')
+
+#-------------------------------------------------------------------------------
+# Tests
+#-------------------------------------------------------------------------------
+
+def new_array(shape, dtype):
+    import numpy
+    return numpy.random.random(shape).astype(dtype)
+
+def test_roundtrip_simple():
+    for obj in [
+        'hello',
+        dict(a='b', b=10),
+        [1,2,'hi'],
+        (b'123', 'hello'),
+    ]:
+        obj2 = roundtrip(obj)
+        nt.assert_equal(obj, obj2)
+
+def test_roundtrip_nested():
+    for obj in [
+        dict(a=range(5), b={1:b'hello'}),
+        [range(5),[range(3),(1,[b'whoda'])]],
+    ]:
+        obj2 = roundtrip(obj)
+        nt.assert_equal(obj, obj2)
+
+def test_roundtrip_buffered():
+    for obj in [
+        dict(a=b"x"*1025),
+        b"hello"*500,
+        [b"hello"*501, 1,2,3]
+    ]:
+        bufs = serialize_object(obj)
+        nt.assert_equal(len(bufs), 2)
+        obj2, remainder = deserialize_object(bufs)
+        nt.assert_equal(remainder, [])
+        nt.assert_equal(obj, obj2)
+
+def test_roundtrip_memoryview():
+    b = b'asdf' * 1025
+    view = memoryview(b)
+    bufs = serialize_object(view)
+    nt.assert_equal(len(bufs), 2)
+    v2, remainder = deserialize_object(bufs)
+    nt.assert_equal(remainder, [])
+    nt.assert_equal(v2.tobytes(), b)
+
+@dec.skip_without('numpy')
+def test_numpy():
+    from numpy.testing.utils import assert_array_equal
+    for shape in SHAPES:
+        for dtype in DTYPES:
+            A = new_array(shape, dtype=dtype)
+            bufs = serialize_object(A)
+            bufs = [memoryview(b) for b in bufs]
+            B, r = deserialize_object(bufs)
+            nt.assert_equal(r, [])
+            nt.assert_equal(A.shape, B.shape)
+            nt.assert_equal(A.dtype, B.dtype)
+            assert_array_equal(A,B)
+
+@dec.skip_without('numpy')
+def test_recarray():
+    from numpy.testing.utils import assert_array_equal
+    for shape in SHAPES:
+        for dtype in [
+            [('f', float), ('s', '|S10')],
+            [('n', int), ('s', '|S1'), ('u', 'uint32')],
+        ]:
+            A = new_array(shape, dtype=dtype)
+
+            bufs = serialize_object(A)
+            B, r = deserialize_object(bufs)
+            nt.assert_equal(r, [])
+            nt.assert_equal(A.shape, B.shape)
+            nt.assert_equal(A.dtype, B.dtype)
+            assert_array_equal(A,B)
+
+@dec.skip_without('numpy')
+def test_numpy_in_seq():
+    from numpy.testing.utils import assert_array_equal
+    for shape in SHAPES:
+        for dtype in DTYPES:
+            A = new_array(shape, dtype=dtype)
+            bufs = serialize_object((A,1,2,b'hello'))
+            canned = pickle.loads(bufs[0])
+            nt.assert_is_instance(canned[0], CannedArray)
+            tup, r = deserialize_object(bufs)
+            B = tup[0]
+            nt.assert_equal(r, [])
+            nt.assert_equal(A.shape, B.shape)
+            nt.assert_equal(A.dtype, B.dtype)
+            assert_array_equal(A,B)
+
+@dec.skip_without('numpy')
+def test_numpy_in_dict():
+    from numpy.testing.utils import assert_array_equal
+    for shape in SHAPES:
+        for dtype in DTYPES:
+            A = new_array(shape, dtype=dtype)
+            bufs = serialize_object(dict(a=A,b=1,c=range(20)))
+            canned = pickle.loads(bufs[0])
+            nt.assert_is_instance(canned['a'], CannedArray)
+            d, r = deserialize_object(bufs)
+            B = d['a']
+            nt.assert_equal(r, [])
+            nt.assert_equal(A.shape, B.shape)
+            nt.assert_equal(A.dtype, B.dtype)
+            assert_array_equal(A,B)
+
+def test_class():
+    @interactive
+    class C(object):
+        a=5
+    bufs = serialize_object(dict(C=C))
+    canned = pickle.loads(bufs[0])
+    nt.assert_is_instance(canned['C'], CannedClass)
+    d, r = deserialize_object(bufs)
+    C2 = d['C']
+    nt.assert_equal(C2.a, C.a)
+
+def test_class_oldstyle():
+    @interactive
+    class C:
+        a=5
+
+    bufs = serialize_object(dict(C=C))
+    canned = pickle.loads(bufs[0])
+    nt.assert_is_instance(canned['C'], CannedClass)
+    d, r = deserialize_object(bufs)
+    C2 = d['C']
+    nt.assert_equal(C2.a, C.a)
+
+def test_tuple():
+    tup = (lambda x:x, 1)
+    bufs = serialize_object(tup)
+    canned = pickle.loads(bufs[0])
+    nt.assert_is_instance(canned, tuple)
+    t2, r = deserialize_object(bufs)
+    nt.assert_equal(t2[0](t2[1]), tup[0](tup[1]))
+
+point = namedtuple('point', 'x y')
+
+def test_namedtuple():
+    p = point(1,2)
+    bufs = serialize_object(p)
+    canned = pickle.loads(bufs[0])
+    nt.assert_is_instance(canned, point)
+    p2, r = deserialize_object(bufs, globals())
+    nt.assert_equal(p2.x, p.x)
+    nt.assert_equal(p2.y, p.y)
+
+def test_list():
+    lis = [lambda x:x, 1]
+    bufs = serialize_object(lis)
+    canned = pickle.loads(bufs[0])
+    nt.assert_is_instance(canned, list)
+    l2, r = deserialize_object(bufs)
+    nt.assert_equal(l2[0](l2[1]), lis[0](lis[1]))
+
+def test_class_inheritance():
+    @interactive
+    class C(object):
+        a=5
+
+    @interactive
+    class D(C):
+        b=10
+
+    bufs = serialize_object(dict(D=D))
+    canned = pickle.loads(bufs[0])
+    nt.assert_is_instance(canned['D'], CannedClass)
+    d, r = deserialize_object(bufs)
+    D2 = d['D']
+    nt.assert_equal(D2.a, D.a)
+    nt.assert_equal(D2.b, D.b)


### PR DESCRIPTION
in deciding whether a buffer is large enough for zero-copy.

len() only gives element count of memoryviews, not bytes, so large numpy arrays could still be copied if their first dimension was small.

Also copies over serialization tests, which were excluded when the serialization code moved here from ipykernel.