### PR TITLE
support 4.2 API for enabling extensions

### DIFF
--- a/ipyparallel/__init__.py
+++ b/ipyparallel/__init__.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """The IPython ZMQ-based parallel computing interface."""
 
 # Copyright (c) IPython Development Team.
@@ -59,4 +60,18 @@ def register_joblib_backend(name='ipyparallel', make_default=False):
     from .joblib import register
     return register(name=name, make_default=make_default)
 
+
+# nbextension installation (requires notebook ≥ 4.2)
+def _jupyter_server_extension_paths():
+    return [{
+        'module': 'ipyparallel.nbextension'
+    }]
+
+def _jupyter_nbextension_paths():
+    return [{
+        'section': 'tree',
+        'src': 'nbextension/static',
+        'dest': 'ipyparallel',
+        'require': 'ipyparallel/main',
+    }]
 

--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -574,7 +574,14 @@ class IPClusterNBExtension(BaseIPythonApplication):
     
     name = 'ipcluster-nbextension'
     
-    description = """Enable/disable IPython clusters tab in Jupyter notebook"""
+    description = """Enable/disable IPython clusters tab in Jupyter notebook
+    
+    for Jupyter Notebook ≥ 4.2, you can use the new nbextension API:
+    
+    jupyter serverextension enable --py ipyparallel
+    jupyter nbextension install --py ipyparallel
+    jupyter nbextension enable --py ipyparallel
+    """
     
     examples = """
     ipcluster nbextension enable

--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -582,16 +582,16 @@ class IPClusterNBExtension(BaseIPythonApplication):
     """
     
     def start(self):
-        from ipyparallel.nbextension.install import install_server_extension
+        from ipyparallel.nbextension.install import install_extensions
         if len(self.extra_args) != 1:
             self.exit("Must specify 'enable' or 'disable'")
         action = self.extra_args[0].lower()
         if action == 'enable':
             print("Enabling IPython clusters tab")
-            install_server_extension(enable=True)
+            install_extensions(enable=True)
         elif action == 'disable':
             print("Disabling IPython clusters tab")
-            install_server_extension(enable=False)
+            install_extensions(enable=False)
         else:
             self.exit("Must specify 'enable' or 'disable', not '%s'" % action)
 

--- a/ipyparallel/nbextension/handlers.py
+++ b/ipyparallel/nbextension/handlers.py
@@ -72,18 +72,22 @@ default_handlers = [
 
 def load_jupyter_server_extension(nbapp):
     """Load the nbserver extension"""
+    from distutils.version import LooseVersion as V
+    import notebook
+    
     nbapp.log.info("Loading IPython parallel extension")
-    windows = sys.platform.startswith('win')
-    install_nbextension(static, destination='ipyparallel', symlink=not windows, user=True)
     webapp = nbapp.web_app
     webapp.settings['cluster_manager'] = ClusterManager(parent=nbapp)
     
-    cfgm = nbapp.config_manager
-    cfgm.update('tree', {
-        'load_extensions': {
-            'ipyparallel/main': True,
-        }
-    })
+    if V(notebook.__version__) < V('4.2'):
+        windows = sys.platform.startswith('win')
+        install_nbextension(static, destination='ipyparallel', symlink=not windows, user=True)
+        cfgm = nbapp.config_manager
+        cfgm.update('tree', {
+            'load_extensions': {
+                'ipyparallel/main': True,
+            }
+        })
     base_url = webapp.settings['base_url']
     webapp.add_handlers(".*$", [
         (ujoin(base_url, pat), handler)

--- a/ipyparallel/nbextension/install.py
+++ b/ipyparallel/nbextension/install.py
@@ -8,11 +8,28 @@ from traitlets.config.manager import BaseJSONConfigManager
 from notebook.services.config import ConfigManager as FrontendConfigManager
 
 
-def install_server_extension(enable=True):
-    """Register ipyparallel clusters tab as a notebook server extension
+def install_extensions(enable=True):
+    """Register ipyparallel clusters tab as notebook extensions
     
     Toggle with enable=True/False.
     """
+    from distutils.version import LooseVersion as V
+    import notebook
+    
+    if V(notebook.__version__) < V('4.2'):
+        return _install_extension_nb41(enable)
+    
+    from notebook.nbextensions import install_nbextension_python, enable_nbextension, disable_nbextension
+    from notebook.serverextensions import toggle_serverextension_python
+    toggle_serverextension_python('ipyparallel.nbextension')
+    install_nbextension_python('ipyparallel')
+    if enable:
+        enable_nbextension('tree', 'ipyparallel/main')
+    else:
+        disable_nbextension('tree', 'ipyparallel/main')
+
+def _install_extension_nb41(enable=True):
+    """deprecated, pre-4.2 implementation of installing notebook extension"""
     # server-side
     server = BaseJSONConfigManager(config_dir=jupyter_config_dir())
     server_cfg = server.get('jupyter_notebook_config')
@@ -41,3 +58,4 @@ def install_server_extension(enable=True):
         }
     })
 
+install_server_extension = install_extensions


### PR DESCRIPTION
Still keeping `ipcluster nbextension enable`, because it's convenient to do it in a single call, where it would be 3 with the new 4.2 API.