### PR TITLE
Added "QoS" and extra options to SlurmLauncher.

### DIFF
--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -576,7 +576,7 @@ class IPClusterNBExtension(BaseIPythonApplication):
     
     description = """Enable/disable IPython clusters tab in Jupyter notebook
     
-    for Jupyter Notebook ≥ 4.2, you can use the new nbextension API:
+    for Jupyter Notebook >= 4.2, you can use the new nbextension API:
     
     jupyter serverextension enable --py ipyparallel
     jupyter nbextension install --py ipyparallel


### PR DESCRIPTION
This patch adds the commonly used "QoS" setting and allows extra Slurm settings through "SlurmLauncher.options" variable, e.g., "c.SlurmLauncher.options = '--export=ALL --mem=10g'".