### PR TITLE
prepare docs for 5.1

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,3 +2,5 @@ name: rtd
 dependencies:
 - python=3
 - ipykernel
+- sphinx>=1.3
+

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,57 @@
 Changes in IPython Parallel
 ===========================
 
+
+5.1
+---
+
+dask, joblib
+************
+
+IPython Parallel 5.1 adds integration with other parallel computing tools,
+such as `dask.distributed <https://distributed.readthedocs.io>`_ and `joblib <https://pythonhosted.org/joblib>`__.
+
+To turn an IPython cluster into a dask.distributed cluster,
+call :meth:`~.Client.become_distributed`::
+
+    executor = client.become_distributed(ncores=1)
+
+which returns a distributed :class:`Executor` instance.
+
+To register IPython Parallel as the backend for joblib::
+
+    import ipyparallel as ipp
+    ipp.register_joblib_backend()
+
+
+nbextensions
+************
+
+IPython parallel now supports the notebook-4.2 API for enabling server extensions,
+to provide the IPython clusters tab::
+
+    jupyter serverextension enable --py ipyparallel
+    jupyter nbextension install --py ipyparallel
+    jupyter nbextension enable --py ipyparallel
+
+though you can still use the more convenient single-call::
+
+    ipcluster nbextension enable
+
+which does all three steps above.
+
+Slurm support
+*************
+
+`Slurm <https://computing.llnl.gov/tutorials/linux_clusters>`_ support is added to ipcluster.
+
+More details on point releases:
+
+5.1.0
+*****
+
+`5.1.0 on GitHub <https://github.com/ipython/ipyparallel/milestones/5.1>`__
+
 5.0
 ---
 
@@ -18,20 +69,20 @@ Changes in IPython Parallel
 5.0.0
 *****
 
-
 `5.0 on GitHub <https://github.com/ipython/ipyparallel/milestones/5.0>`__
 
 The highlight of ipyparallel 5.0 is that the Client has been reorganized a bit to use Futures.
-AsyncResults are now a Future subclass, so they can be `yield`ed in coroutines, etc.
+AsyncResults are now a Future subclass, so they can be `yield` ed in coroutines, etc.
 Views have also received an Executor interface.
 This rewrite better connects results to their handles,
 so the Client.results cache should no longer grow unbounded.
 
 .. seealso::
 
-     - The Executor API :class:`ipyparallel.ViewExecutor`
-     - Creating an Executor from a Client: :meth:`ipyparallel.Client.executor`
-     - Each View has an :attr:`executor` attribute
+    - The Executor API :class:`ipyparallel.ViewExecutor`
+    - Creating an Executor from a Client: :meth:`ipyparallel.Client.executor`
+    - Each View has an :attr:`executor` attribute
+
 
 Part of the Future refactor is that Client IO is now handled in a background thread,
 which means that :meth:`Client.spin_thread` is obsolete and deprecated.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
+    'IPython.sphinxext.ipython_console_highlighting',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -319,4 +319,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
-                       'ipython': ('https://ipython.org/ipython-doc/dev/', None),}
+                       'ipython': ('https://ipython.readthedocs.io/en/stable/', None),
+                       'distributed': ('https://distributed.readthedocs.io/en/stable/', None),
+                       'jupyterclient': ('https://jupyter-client.readthedocs.io/en/stable/', None),
+                   }

--- a/docs/source/development/messages.rst
+++ b/docs/source/development/messages.rst
@@ -3,7 +3,7 @@
 Messaging for Parallel Computing
 ================================
 
-This is an extension of the :ref:`messaging <messaging>` doc. Diagrams of the connections
+This is an extension of the :ref:`messaging <jupyterclient:messaging>` doc. Diagrams of the connections
 can be found in the :ref:`parallel connections <parallel_connections>` doc.
 
 
@@ -84,7 +84,7 @@ Heartbeat
 *********
 
 The hub uses a heartbeat system to monitor engines, and track when they become
-unresponsive. As described in :ref:`messaging <messaging>`, and shown in :ref:`connections
+unresponsive. As described in :ref:`messaging <jupyterclient:messaging>`, and shown in :ref:`connections
 <parallel_connections>`.
 
 Notification (``PUB``)

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -94,7 +94,7 @@ IPython engine
 
 The IPython engine is an extension of the IPython kernel for Jupyter.
 The engine listens for requests over the network, runs code, and returns results.
-IPython parallel extends the :ref:`Jupyter messaging protocol <messaging>`
+IPython parallel extends the :ref:`Jupyter messaging protocol <jupyterclient:messaging>`
 to support native Python object serialization.
 When multiple engines are started, parallel and distributed computing becomes possible.
 


### PR DESCRIPTION
cc @willingc

I do want to merge the example notebooks into the documentation like we now do on nbconvert,
but not for this release.