### PR TITLE
raise the right RemoteError when iterating through a failed AsyncResult

### DIFF
--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -386,9 +386,9 @@ class AsyncResult(Future):
             evt = Event()
             for child in self._children:
                 self._wait_for_child(child, evt=evt)
-                results = child.result()
-                error.collect_exceptions([results], self._fname)
-                yield results
+                result = child.result()
+                error.collect_exceptions([result], self._fname)
+                yield result
         else:
             # already done
             for r in rlist:
@@ -678,15 +678,11 @@ class AsyncMapResult(AsyncResult):
         for use in iterator methods
         """
         rlist = child.result()
+        if not isinstance(rlist, list):
+            rlist = [rlist]
         error.collect_exceptions(rlist, self._fname)
-        try:
-            for r in rlist:
-                yield r
-        except TypeError:
-            # flattened, not a list
-            # this could get broken by flattened data that returns iterables
-            # but most calls to map do not expose the `flatten` argument
-            yield rlist
+        for r in rlist:
+            yield r
     
     # asynchronous ordered iterator:
     def _ordered_iter(self):

--- a/ipyparallel/tests/test_asyncresult.py
+++ b/ipyparallel/tests/test_asyncresult.py
@@ -91,6 +91,16 @@ class AsyncResultTest(ClusterTestCase):
         for r in ar:
             self.assertEqual(r, 0.125)
     
+    def test_iter_error(self):
+        amr = self.client[:].map_async(lambda x: 1/(x-2), range(5))
+        # iterating through failing AMR should raise RemoteError
+        self.assertRaisesRemote(ZeroDivisionError, list, amr)
+        # so should get
+        self.assertRaisesRemote(ZeroDivisionError, amr.get)
+        amr.wait(10)
+        # test iteration again after everything is local
+        self.assertRaisesRemote(ZeroDivisionError, list, amr)
+    
     def test_getattr(self):
         ar = self.client[:].apply_async(wait, 0.5)
         self.assertEqual(ar.engine_id, [None] * len(ar))


### PR DESCRIPTION
in which case `child.result()` will be a RemoteError, not a list

closes #162
closes #163

@jakirkham can you test this? I'm guessing this is what you've been seeing.