### PR TITLE
Import joblib classes from public module

### DIFF
--- a/ipyparallel/client/_joblib.py
+++ b/ipyparallel/client/_joblib.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import
 
 import ipyparallel as ipp
-from joblib._parallel_backends import ParallelBackendBase, AutoBatchingMixin
+from joblib.parallel import ParallelBackendBase, AutoBatchingMixin
 
 class IPythonParallelBackend(AutoBatchingMixin, ParallelBackendBase):
 


### PR DESCRIPTION
for ParallelBackendBase and AutoBatchingMixin.

Both classes have been exposed in joblib.parallel in joblib/joblib@1eb46ca which is in joblib 0.10.2.
