### PR TITLE
increase default `wait_for_url_file` to 10 seconds

### DIFF
--- a/ipyparallel/apps/ipengineapp.py
+++ b/ipyparallel/apps/ipengineapp.py
@@ -138,7 +138,7 @@ class IPEngineApp(BaseParallelApplication):
         security directory of the cluster directory.  This location is
         resolved using the `profile` or `profile_dir` options.""",
         )
-    wait_for_url_file = Float(5, config=True,
+    wait_for_url_file = Float(10, config=True,
         help="""The maximum number of seconds to wait for url_file to exist.
         This is useful for batch-systems and shared-filesystems where the
         controller and engine are started at the same time and it


### PR DESCRIPTION
On our PBS cluster we have had a lot of issues of engines not starting. We now discovered that increasing `wait_for_url_file` worked for us.

For example you would try to start 200 engines, but only 160 would start, but sometimes (busy times) only a handful would start.

Of course changing the variable in the config would work for us, but considering others might encounter the same problems and might never find out this option, I propose to change the default.