### PR TITLE
Improve location handling

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -201,7 +201,7 @@ circumstances:
       "url":"tcp:\/\/127.0.0.1:54424",
       "exec_key":"a361fe89-92fc-4762-9767-e2f0a05e3130",
       "ssh":"",
-      "location":"10.19.1.135"
+      "location":"yourmachine.local"
     }
 
 If, however, you are running the controller on a work node on a cluster, you will likely
@@ -218,7 +218,7 @@ on the cluster.  An example of ipcontroller-client.json, as created by::
       "url":"tcp:\/\/*:54424",
       "exec_key":"a361fe89-92fc-4762-9767-e2f0a05e3130",
       "ssh":"login.mycluster.com",
-      "location":"10.0.0.2"
+      "location":"yourmachine.local"
     }
 
 More details of how these JSON files are used are given below.

--- a/docs/source/process.rst
+++ b/docs/source/process.rst
@@ -43,7 +43,7 @@ Or you can set the same behavior as the default by adding the following line to 
 .. sourcecode:: python
 
     c.HubFactory.ip = '*'
-    # c.HubFactory.location = '10.0.1.1'
+    # c.HubFactory.location = 'controllerhost.tld'
 
 
 .. note::
@@ -51,10 +51,16 @@ Or you can set the same behavior as the default by adding the following line to 
     ``--ip=*`` instructs ZeroMQ to listen on all interfaces,
     but it does not contain the IP needed for engines / clients
     to know where the controller actually is.
-    This can be specified with ``--location=10.0.0.1``,
-    the specific IP address of the controller, as seen from engines and/or clients.
-    IPython tries to guess this value by default, but it will not always guess correctly.
+    This can be specified with the ``--location`` argument,
+    such as ``--location=10.0.0.1``, or ``--location=server.local``,
+    the specific IP address or hostname of the controller, as seen from engines and/or clients.
+    IPython uses ``socket.gethostname()`` for this value by default,
+    but it may not always be the right value.
     Check the ``location`` field in your connection files if you are having connection trouble.
+
+.. versionchanged:: 6.1
+
+    Support hostnames in location, in addition to ip addresses.
 
 .. note::
 

--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -422,6 +422,7 @@ start_aliases.update(dict(
     delay='IPClusterStart.delay',
     controller='IPClusterStart.controller_launcher_class',
     ip='IPClusterStart.controller_ip',
+    location='IPClusterStart.controller_location',
 ))
 start_aliases['clean-logs'] = 'IPClusterStart.clean_logs'
 
@@ -445,6 +446,12 @@ class IPClusterStart(IPClusterEngines):
         help="delay (in s) between starting the controller and the engines")
 
     controller_ip = Unicode(config=True, help="Set the IP address of the controller.")
+    controller_location = Unicode(config=True,
+        help="""Set the location (hostname or ip) of the controller.
+        
+        This is used by engines and clients to locate the controller
+        when the controller listens on all interfaces
+        """)
     controller_launcher = Any(config=True, help="Deprecated, use controller_launcher_class")
     def _controller_launcher_changed(self, name, old, new):
         if isinstance(new, string_types):
@@ -495,8 +502,11 @@ class IPClusterStart(IPClusterEngines):
 
     def init_launchers(self):
         self.controller_launcher = self.build_launcher(self.controller_launcher_class, 'Controller')
+        controller_args = self.controller_launcher.controller_args
         if self.controller_ip:
-            self.controller_launcher.controller_args.append('--ip=%s' % self.controller_ip)
+            controller_args.append('--ip=%s' % self.controller_ip)
+        if self.controller_location:
+            controller_args.append('--location=%s' % self.controller_location)
         self.engine_launcher = self.build_launcher(self.engine_launcher_class, 'EngineSet')
 
     def engines_stopped(self, r):

--- a/ipyparallel/apps/launcher.py
+++ b/ipyparallel/apps/launcher.py
@@ -341,7 +341,7 @@ class LocalControllerLauncher(LocalProcessLauncher, ControllerMixin):
 
 
 class LocalEngineLauncher(LocalProcessLauncher, EngineMixin):
-    """Launch a single engine as a regular externall process."""
+    """Launch a single engine as a regular external process."""
 
     def find_args(self):
         return self.engine_cmd + self.cluster_args + self.engine_args

--- a/ipyparallel/tests/test_util.py
+++ b/ipyparallel/tests/test_util.py
@@ -1,0 +1,13 @@
+import socket
+from ipyparallel import util
+from jupyter_client.localinterfaces import localhost, public_ips
+
+
+def test_disambiguate_ip():
+    # garbage in, garbage out
+    public_ip = public_ips()[0]
+    assert util.disambiguate_ip_address('garbage') == 'garbage'
+    assert util.disambiguate_ip_address('0.0.0.0', socket.gethostname()) == localhost()
+    wontresolve = 'this.wontresolve.dns'
+    assert util.disambiguate_ip_address('0.0.0.0', wontresolve) == wontresolve
+    assert util.disambiguate_ip_address('0.0.0.0', public_ip) == localhost()

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -4,6 +4,15 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+try:
+    from functools import lru_cache
+except ImportError:
+    # py2 has no lru_cache decorator,
+    # use a no-op
+    def lru_cache(maxsize=0):
+        """no-op decorator when lru_cache is unavailable"""
+        return lambda f: f
+
 import logging
 import os
 import re
@@ -16,7 +25,7 @@ from signal import signal, SIGINT, SIGABRT, SIGTERM
 try:
     from signal import SIGKILL
 except ImportError:
-    SIGKILL=None
+    SIGKILL = None
 from types import FunctionType
 
 from dateutil.parser import parse as dateutil_parse
@@ -185,6 +194,7 @@ def is_ip(location):
     return bool(re.match(location, '(\d+\.){3}\d+'))
 
 
+@lru_cache()
 def ip_for_host(host):
     """Get the ip address for a host
     


### PR DESCRIPTION
- add `--location` argument to `ipcluster start` for setting
- allow location to be a hostname, not just an ip
- use `socket.gethostname()` for the default location,
  which should work pretty often on LANs.