### PR TITLE
pass through extra args from ipcluster start to ipcontroller

### DIFF
--- a/docs/source/db.rst
+++ b/docs/source/db.rst
@@ -10,16 +10,21 @@ Enabling a DB Backend
 The IPython Hub can store all task requests and results in a database.
 Currently supported backends are: MongoDB, SQLite, and an in-memory DictDB.
 
-This database behavior is optional due to its potential :ref:`db_cost`,
-so you must enable one, either at the command-line::
+The default is to store recent tasks in a dictionary in memory,
+which deletes old values if it gets too big, and only survives
+as long as the controller is running.
 
-    $> ipcontroller --dictb # or --mongodb or --sqlitedb
+Using a real database is optional due to its potential :ref:`db_cost`.
+You can enable one, either at the command-line::
+
+    $> ipcontroller --sqlitedb # or --mongodb or --nodb
 
 or in your :file:`ipcontroller_config.py`:
 
 .. sourcecode:: python
 
-    c.HubFactory.db_class = "DictDB"
+    c.HubFactory.db_class = "NoDB"
+    c.HubFactory.db_class = "DictDB" # default
     c.HubFactory.db_class = "MongoDB"
     c.HubFactory.db_class = "SQLiteDB"
 

--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -57,6 +57,10 @@ ipcluster engines -h  # show the help string for the engines subcmd
 _start_examples = """
 ipython profile create mycluster --parallel # create mycluster profile
 ipcluster start --profile=mycluster --n=4   # start mycluster with 4 nodes
+
+# args to `ipcluster start` after `--` are passed through to the controller
+# see `ipcontroller -h` for options
+ipcluster start -- --sqlitedb
 """
 
 _stop_examples = """
@@ -507,6 +511,8 @@ class IPClusterStart(IPClusterEngines):
             controller_args.append('--ip=%s' % self.controller_ip)
         if self.controller_location:
             controller_args.append('--location=%s' % self.controller_location)
+        if self.extra_args:
+            controller_args.extend(self.extra_args)
         self.engine_launcher = self.build_launcher(self.engine_launcher_class, 'EngineSet')
 
     def engines_stopped(self, r):


### PR DESCRIPTION
use standard `--` to stop parsing args for ipcluster itself, so to specify controller args:

    ipcluster start --engines=MPI -- [controller args go here]

and make docs clearer that DictDB is the default.

closes #242