### PR TITLE
support canning partial functions

### DIFF
--- a/ipyparallel/tests/test_canning.py
+++ b/ipyparallel/tests/test_canning.py
@@ -1,4 +1,4 @@
-
+from binascii import b2a_hex
 from functools import partial
 import os
 import pickle
@@ -81,7 +81,7 @@ def test_can_partial():
 
 def test_can_partial_buffers():
     def foo(arg1, arg2, kwarg1, kwarg2):
-        return '%s%s%s%s' % (arg1, arg2, kwarg1.hex(), kwarg2)
+        return '%s%s%s%s' % (arg1, arg2, b2a_hex(bytes(kwarg1)), kwarg2)
 
     buf1 = os.urandom(1024 * 1024)
     buf2 = memoryview(os.urandom(1024 * 1024))

--- a/ipyparallel/tests/test_canning.py
+++ b/ipyparallel/tests/test_canning.py
@@ -81,7 +81,7 @@ def test_can_partial():
 
 def test_can_partial_buffers():
     def foo(arg1, arg2, kwarg1, kwarg2):
-        return '%s%s%s%s' % (arg1, arg2, b2a_hex(bytes(kwarg1)), kwarg2)
+        return '%s%s%s%s' % (arg1, arg2[:32], b2a_hex(kwarg1.tobytes()[:32]), kwarg2)
 
     buf1 = os.urandom(1024 * 1024)
     buf2 = memoryview(os.urandom(1024 * 1024))


### PR DESCRIPTION
allows:

    map(func, [arg]*len(map_args), map_args)

to become

    map(partial(func, arg), map_args)

which is nicer