### PR TITLE
only import IPython's signatures backport when needed

### DIFF
--- a/ipyparallel/client/remotefunction.py
+++ b/ipyparallel/client/remotefunction.py
@@ -12,7 +12,10 @@ from decorator import decorator
 
 from . import map as Map
 from .asyncresult import AsyncMapResult
-from IPython.utils.signatures import signature
+try:
+    from inspect import signature
+except ImportError: # py2
+    from IPython.utils.signatures import signature
 
 #-----------------------------------------------------------------------------
 # Functions and Decorators


### PR DESCRIPTION
inspect.signature is defined in Python 3, only import IPython.utils.signature on Python 2.

IPython 6, which drops support for Python 2, has deprecated the utils.signature backport.