### PR TITLE
Reduce the value of _FOREVER in asyncresult.py so that Overflow Error…

### DIFF
--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -45,7 +45,7 @@ def check_ready(f, self, *args, **kwargs):
     return f(self, *args, **kwargs)
 
 _metadata_keys = []
-_FOREVER = int(1e8) # a long time because some infinite timeouts are uninterruptible
+_FOREVER = int(1e6) # a long time because some infinite timeouts are uninterruptible
 
 class AsyncResult(Future):
     """Class for representing results of non-blocking calls.

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -9,6 +9,7 @@ import sys
 import time
 from concurrent.futures import Future
 from datetime import datetime
+import threading
 from threading import Event
 try:
     from queue import Queue
@@ -45,7 +46,8 @@ def check_ready(f, self, *args, **kwargs):
     return f(self, *args, **kwargs)
 
 _metadata_keys = []
-_FOREVER = int(1e6) # a long time because some infinite timeouts are uninterruptible
+# threading.TIMEOUT_MAX new in 3.2
+_FOREVER = getattr(threading, 'TIMEOUT_MAX', int(1e6))
 
 class AsyncResult(Future):
     """Class for representing results of non-blocking calls.


### PR DESCRIPTION
… is not raised.

The value of _thread.TIMEOUT_MAX is 4294967.0 in Windows, so the original value of _FOREVER=1e8
is too large. Overflow Error is raised at line 716 of asyncresult.py where 
    child = queue.get(timeout=_FOREVER)
is executed.
