### PR TITLE
Interleave jobs

### DIFF
--- a/ipyparallel/controller/scheduler.py
+++ b/ipyparallel/controller/scheduler.py
@@ -15,7 +15,7 @@ import time
 from pprint import pprint
 from collections import deque
 from datetime import datetime
-from random import randint, random
+from random import randint, random, shuffle
 from types import FunctionType
 
 try:
@@ -729,6 +729,7 @@ help="""select the task scheduler scheme  [default: Python LRU]
         self.log.debug("Original order: " + str([j.msg_id+"@"+j.header['session'] for j in jobs]))
         if order == 'interleaved':
             sessions = split_by_session(jobs).values()
+            shuffle(sessions)
             interleaved = roundrobin(sessions)
             self.log.debug("New order: " + str([j.msg_id+"@"+j.header['session'] for j in interleaved]))
             return deque(interleaved)


### PR DESCRIPTION
I'm using ipyparallel with the following use case:
User 1 submits 100 jobs that take a minute each,
User 2 submits 10 jobs that take a minute each.

Vanilla ipyparallel will make User 2 wait until all of User 1's jobs are finished before starting on its jobs.
This change interleaves the jobs. So rather than 
1 1 1 1 1 1 1 1 2 2 2
jobs will be executed as
1 2 1 2 1 2 1 1 1 1 1 

In my case I have multiple users using the cluster, this change prevents frustration. All jobs tend to take well over 10 minutes, this allows us to share resources.

Would like to make this a config parameter.