### PR TITLE
implement extension enabling via data_files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@ include COPYING.md
 include CONTRIBUTING.md
 include README.md
 
+graft etc
+
 # Documentation
 graft docs
 

--- a/etc/ipyparallel-nbextension.json
+++ b/etc/ipyparallel-nbextension.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "ipyparallel/main": true
+  }
+}

--- a/etc/ipyparallel-serverextension.json
+++ b/etc/ipyparallel-serverextension.json
@@ -1,0 +1,7 @@
+{
+    "NotebookApp": {
+        "nbserver_extensions": {
+            "ipyparallel.nbextension": true
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,10 @@ data_files = [
         'etc/jupyter/nbconfig/tree.d',
         [pjoin(here, 'etc', 'ipyparallel-nbextension.json')],
     ),
+    (
+        'share/jupyter/nbextensions/ipyparallel',
+        glob(pjoin(here, 'ipyparallel', 'nbextension', 'static', '*')),
+    ),
 ]
 
 version_ns = {}

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,17 @@ for d, _, _ in os.walk(pjoin(here, name)):
 
 package_data = {'ipyparallel.nbextension': [pjoin('static', '*')]}
 
+data_files = [
+    (
+        'etc/jupyter/jupyter_notebook_config.d',
+        [pjoin(here, 'etc', 'ipyparallel-serverextension.json')],
+    ),
+    (
+        'etc/jupyter/nbconfig/tree.d',
+        [pjoin(here, 'etc', 'ipyparallel-nbextension.json')],
+    ),
+]
+
 version_ns = {}
 with open(pjoin(here, name, '_version.py')) as f:
     exec(f.read(), {}, version_ns)
@@ -111,6 +122,7 @@ setup_args = dict(
         "test": IPTestCommand,
         "bdist_egg": bdist_egg if "bdist_egg" in sys.argv else bdist_egg_disabled,
     },
+    data_files=data_files,
     install_requires=[
         "ipython_genutils",
         "decorator",


### PR DESCRIPTION
installing ipyparallel enables notebook extensions via conf.d files for notebook >= 5.3