### PR TITLE
Handle heartbeat-failed already-stopped engines.

### DIFF
--- a/ipyparallel/controller/heartmonitor.py
+++ b/ipyparallel/controller/heartmonitor.py
@@ -171,7 +171,10 @@ class HeartMonitor(LoggingConfigurable):
                     pass
         else:
             self.log.info("heartbeat::Heart %s failed :(", heart)
-        self.hearts.remove(heart)
+        try:
+            self.hearts.remove(heart)
+        except KeyError:
+            self.log.info("heartbeat:: %s has already been removed." % heart)
 
 
     @log_errors


### PR DESCRIPTION
Hi ya'll, if the engine has already stopped running, the heartbeat checker throws an exception if it tries to remove it from the engine set of already running engines. This handles that race condition gracefully.