### PR TITLE
Fix #320 jQuery attribute selector value MUST be surrounded by quotes

### DIFF
--- a/ipyparallel/nbextension/static/main.js
+++ b/ipyparallel/nbextension/static/main.js
@@ -33,7 +33,7 @@ define(function(require) {
         if (!IPython.notebook_list) return;
         var base_url = IPython.notebook_list.base_url;
         // hide the deprecated clusters tab
-        $("#tabs").find('[href=#clusters]').hide();
+        $("#tabs").find('[href="#clusters"]').hide();
         $('head').append(
             $('<link>')
             .attr('rel', 'stylesheet')


### PR DESCRIPTION
To avoid `Error: Syntax error, unrecognized expression: [href=#clusters]`