### PR TITLE
use relative paths in data_files

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,11 @@
 Changes in IPython Parallel
 ===========================
 
+6.2.1
+-----
+
+- Workaround a setuptools issue preventing installation from sdist on Windows
+
 6.2.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -80,15 +80,15 @@ package_data = {'ipyparallel.nbextension': [pjoin('static', '*')]}
 data_files = [
     (
         'etc/jupyter/jupyter_notebook_config.d',
-        [pjoin(here, 'etc', 'ipyparallel-serverextension.json')],
+        [pjoin('etc', 'ipyparallel-serverextension.json')],
     ),
     (
         'etc/jupyter/nbconfig/tree.d',
-        [pjoin(here, 'etc', 'ipyparallel-nbextension.json')],
+        [pjoin('etc', 'ipyparallel-nbextension.json')],
     ),
     (
         'share/jupyter/nbextensions/ipyparallel',
-        glob(pjoin(here, 'ipyparallel', 'nbextension', 'static', '*')),
+        glob(pjoin('ipyparallel', 'nbextension', 'static', '*')),
     ),
 ]
 


### PR DESCRIPTION
setuptools makes an sdist that somehow doesn't work on Windows if you don't do this