### PR TITLE
tornado 4 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,34 @@
 # http://travis-ci.org/#!/ipython/ipyparallel
 language: python
 python:
-    - "nightly"
-    - 3.6
-    - 2.7
-    - 3.5
-    - 3.4
+  - "nightly"
+  - 3.6
+  - 2.7
+  - 3.5
+  - 3.4
 sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
 install:
-    - pip install --upgrade setuptools pip
-    - pip install --pre --upgrade .[test] distributed joblib codecov
-    - 'pip install --only-binary :all: matplotlib || echo "no matplotlib"'
+  - pip install --upgrade setuptools pip
+  - pip install --pre --upgrade .[test] distributed joblib codecov
+  - |
+    # install pinned tornado
+    if [[ ! -z "$TORNADO" ]]; then
+      pip install tornado==${TORNADO}
+    fi
+  - 'pip install --only-binary :all: matplotlib || echo "no matplotlib"'
+  - pip freeze
 script:
-    - pytest --maxfail=3 --cov ipyparallel -vsx ipyparallel/tests
+  - pytest --maxfail=3 --cov ipyparallel -vsx ipyparallel/tests
 after_success:
-    - codecov
+  - codecov
 matrix:
-    allow_failures:
-        - python: "nightly"
+  allow_failures:
+    - python: "nightly"
+  include:
+    - python: 3.6
+      env: TORNADO="4.5.3"
+    - python: 2.7
+      env: TORNADO="4.5.3"

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -850,7 +850,9 @@ class Client(HasTraits):
                 # no asyncio loop, make one
                 # e.g.
                 asyncio.set_event_loop(asyncio.new_event_loop())
-        return IOLoop.current()
+        loop = IOLoop()
+        loop.make_current()
+        return loop
 
     def _stop_io_thread(self):
         """Stop my IO thread"""
@@ -860,17 +862,17 @@ class Client(HasTraits):
             self._io_thread.join()
 
     def _setup_streams(self):
-        self._query_stream = ZMQStream(self._query_socket)
+        self._query_stream = ZMQStream(self._query_socket, self._io_loop)
         self._query_stream.on_recv(self._dispatch_single_reply, copy=False)
-        self._control_stream = ZMQStream(self._control_socket)
+        self._control_stream = ZMQStream(self._control_socket, self._io_loop)
         self._control_stream.on_recv(self._dispatch_single_reply, copy=False)
-        self._mux_stream = ZMQStream(self._mux_socket)
+        self._mux_stream = ZMQStream(self._mux_socket, self._io_loop)
         self._mux_stream.on_recv(self._dispatch_reply, copy=False)
-        self._task_stream = ZMQStream(self._task_socket)
+        self._task_stream = ZMQStream(self._task_socket, self._io_loop)
         self._task_stream.on_recv(self._dispatch_reply, copy=False)
-        self._iopub_stream = ZMQStream(self._iopub_socket)
+        self._iopub_stream = ZMQStream(self._iopub_socket, self._io_loop)
         self._iopub_stream.on_recv(self._dispatch_iopub, copy=False)
-        self._notification_stream = ZMQStream(self._notification_socket)
+        self._notification_stream = ZMQStream(self._notification_socket, self._io_loop)
         self._notification_stream.on_recv(self._dispatch_notification, copy=False)
 
     def _start_io_thread(self):


### PR DESCRIPTION
With tornado 4, we were not instantiating the background IOLoop correctly

- instantiate IOLoop explicitly and call `.make_current()`
- pass IOLoop instance to ZMQStream constructors, which refer to `IOLoop.instance` if unspecified, not `IOLoop.current`

closes #334