### PR TITLE
add missing super().__init__ in joblib backend

### DIFF
--- a/ipyparallel/client/_joblib.py
+++ b/ipyparallel/client/_joblib.py
@@ -10,6 +10,7 @@ from joblib.parallel import ParallelBackendBase, AutoBatchingMixin
 class IPythonParallelBackend(AutoBatchingMixin, ParallelBackendBase):
 
     def __init__(self, view=None):
+        super(IPythonParallelBackend, self).__init__()
         if view is None:
             self._owner = True
             rc = ipp.Client()


### PR DESCRIPTION
Needed for tests with latest joblib release (0.12)