### PR TITLE
Remove execute_request override

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup_args = dict(
         "traitlets>=4.3",
         "ipython>=4",
         "jupyter_client",
-        "ipykernel",
+        "ipykernel>=4.4",
         "tornado>=4",
         "python-dateutil>=2.1",
     ],


### PR DESCRIPTION
This is no longer required with ipykernel>=4.4 and doesn't work with ipykernel 5.0

require ipykernel 4.4 to ensure the required init/finish_metadata methods are defined