### PR TITLE
Use unittest.mock if available

### DIFF
--- a/ipyparallel/tests/test_client.py
+++ b/ipyparallel/tests/test_client.py
@@ -12,7 +12,10 @@ import os
 import sys
 from threading import Thread
 import time
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
 import tornado


### PR DESCRIPTION
Use unittest.mock if available in ipyparallel/tests/test_client.py, as is already the case in ipyparallel/tests/test_joblib.py and ipyparallel/tests/test_apps.py.

