### PR TITLE
Compatibility fixes for Python 3.7, 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 # http://travis-ci.org/#!/ipython/ipyparallel
+dist: xenial
 language: python
 python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8-dev"
   - "nightly"
-  - 3.6
-  - 2.7
-  - 3.5
-  - 3.4
 sudo: false
 cache:
   directories:
@@ -26,6 +29,7 @@ after_success:
   - codecov
 matrix:
   allow_failures:
+    - python: "3.8-dev"
     - python: "nightly"
   include:
     - python: 3.6

--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -18,8 +18,9 @@ from IPython.core.profiledir import ProfileDir
 from ipython_genutils.importstring import import_item
 from ipython_genutils.py3compat import string_types
 from IPython.utils.sysinfo import num_cpus
-from traitlets import (Integer, Unicode, Bool, CFloat, Dict, List, Any,
-                                        DottedObjectName)
+from traitlets import (
+    Integer, Unicode, Bool, CFloat, Dict, List, Any, DottedObjectName, observe
+)
 
 from .baseapp import (
     BaseParallelApplication,
@@ -242,11 +243,13 @@ class IPClusterEngines(BaseParallelApplication):
         CPU on your machine""")
 
     engine_launcher = Any(config=True, help="Deprecated, use engine_launcher_class")
-    def _engine_launcher_changed(self, name, old, new):
-        if isinstance(new, string_types):
+
+    @observe('engine_launcher')
+    def _engine_launcher_changed(self, change):
+        if isinstance(change['new'], string_types):
             self.log.warn("WARNING: %s.engine_launcher is deprecated as of 0.12,"
                     " use engine_launcher_class" % self.__class__.__name__)
-            self.engine_launcher_class = new
+            self.engine_launcher_class = change['new']
     engine_launcher_class = DottedObjectName('LocalEngineSetLauncher',
         config=True,
         help="""The class for launching a set of Engines. Change this value
@@ -288,8 +291,9 @@ class IPClusterEngines(BaseParallelApplication):
         Not available on Windows.
         """)
 
-    def _daemonize_changed(self, name, old, new):
-        if new:
+    @observe('daemonize')
+    def _daemonize_changed(self, change):
+        if change['new']:
             self.log_to_file = True
 
     early_shutdown = Integer(30, config=True, help="The timeout (in seconds)")
@@ -457,12 +461,14 @@ class IPClusterStart(IPClusterEngines):
         when the controller listens on all interfaces
         """)
     controller_launcher = Any(config=True, help="Deprecated, use controller_launcher_class")
-    def _controller_launcher_changed(self, name, old, new):
-        if isinstance(new, string_types):
+
+    @observe('controller_launcher')
+    def _controller_launcher_changed(self, change):
+        if isinstance(change['new'], string_types):
             # old 0.11-style config
             self.log.warn("WARNING: %s.controller_launcher is deprecated as of 0.12,"
                     " use controller_launcher_class" % self.__class__.__name__)
-            self.controller_launcher_class = new
+            self.controller_launcher_class = change['new']
     controller_launcher_class = DottedObjectName('LocalControllerLauncher',
         config=True,
         help="""The class for launching a Controller. Change this value if you want

--- a/ipyparallel/apps/ipengineapp.py
+++ b/ipyparallel/apps/ipengineapp.py
@@ -28,15 +28,12 @@ from jupyter_client.session import (
 )
 from ipykernel.zmqshell import ZMQInteractiveShell
 
-from traitlets.config.configurable import Configurable
-
 from ipyparallel.engine.log import EnginePUBHandler
 from ipyparallel.engine.engine import EngineFactory
 from ipyparallel.util import disambiguate_ip_address
 
 from ipython_genutils.py3compat import cast_bytes
-from traitlets import Unicode, Dict, List, Float, Instance
-from ipykernel import iostream
+from traitlets import Unicode, Dict, List, Float, Instance, observe
 
 #-----------------------------------------------------------------------------
 # Module level variables
@@ -112,9 +109,10 @@ class IPEngineApp(BaseParallelApplication):
 
     url_file_name = Unicode(u'ipcontroller-engine.json', config=True)
 
-    def _cluster_id_changed(self, name, old, new):
-        if new:
-            base = 'ipcontroller-%s' % new
+    @observe('cluster_id')
+    def _cluster_id_changed(self, change):
+        if change['new']:
+            base = 'ipcontroller-{}'.format(change['new'])
         else:
             base = 'ipcontroller'
         self.url_file_name = "%s-engine.json" % base

--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -23,8 +23,9 @@ from ..util import extract_dates
 from jupyter_client.localinterfaces import localhost
 from ipython_genutils.py3compat import cast_bytes, unicode_type, iteritems, buffer_to_bytes_py2
 from traitlets import (
-        HasTraits, Any, Instance, Integer, Unicode, Dict, Set, Tuple, DottedObjectName
-        )
+    HasTraits, Any, Instance, Integer, Unicode, Dict, Set, Tuple,
+    DottedObjectName, observe
+)
 
 from ipyparallel import error, util
 from ipyparallel.factory import RegistrationFactory
@@ -213,7 +214,9 @@ class HubFactory(RegistrationFactory):
     db = Instance('ipyparallel.controller.dictdb.BaseDB', allow_none=True)
     heartmonitor = Instance('ipyparallel.controller.heartmonitor.HeartMonitor', allow_none=True)
 
-    def _ip_changed(self, name, old, new):
+    @observe('ip')
+    def _ip_changed(self, change):
+        new = change['new']
         self.engine_ip = new
         self.client_ip = new
         self.monitor_ip = new
@@ -222,7 +225,9 @@ class HubFactory(RegistrationFactory):
     def _update_monitor_url(self):
         self.monitor_url = "%s://%s:%i" % (self.monitor_transport, self.monitor_ip, self.mon_port)
 
-    def _transport_changed(self, name, old, new):
+    @observe('transport')
+    def _transport_changed(self, change):
+        new = change['new']
         self.engine_transport = new
         self.client_transport = new
         self.monitor_transport = new

--- a/ipyparallel/controller/scheduler.py
+++ b/ipyparallel/controller/scheduler.py
@@ -27,7 +27,7 @@ from zmq.eventloop import zmqstream
 from decorator import decorator
 from traitlets.config.application import Application
 from traitlets.config.loader import Config
-from traitlets import Instance, Dict, List, Set, Integer, Enum, CBytes
+from traitlets import Instance, Dict, List, Set, Integer, Enum, CBytes, observe
 from ipython_genutils.py3compat import cast_bytes
 
 from ipyparallel import error, util
@@ -173,9 +173,11 @@ class TaskScheduler(SessionFactory):
 help="""select the task scheduler scheme  [default: Python LRU]
         Options are: 'pure', 'lru', 'plainrandom', 'weighted', 'twobin','leastload'"""
     )
-    def _scheme_name_changed(self, old, new):
-        self.log.debug("Using scheme %r"%new)
-        self.scheme = globals()[new]
+
+    @observe('scheme_name')
+    def _scheme_name_changed(self, change):
+        self.log.debug("Using scheme %r" % change['new'])
+        self.scheme = globals()[change['new']]
 
     # input arguments:
     scheme = Instance(FunctionType) # function for determining the destination

--- a/ipyparallel/engine/engine.py
+++ b/ipyparallel/engine/engine.py
@@ -18,7 +18,7 @@ from zmq.eventloop import zmqstream
 from jupyter_client.localinterfaces import localhost
 from traitlets import (
     Instance, Dict, Integer, Type, Float, Unicode, CBytes, Bool,
-    default,
+    default, observe
 )
 from ipython_genutils.py3compat import cast_bytes
 
@@ -115,8 +115,10 @@ class EngineFactory(RegistrationFactory):
 
     bident = CBytes()
     ident = Unicode()
-    def _ident_changed(self, name, old, new):
-        self.bident = cast_bytes(new)
+
+    @observe('ident')
+    def _ident_changed(self, change):
+        self.bident = cast_bytes(change['new'])
     using_ssh=Bool(False)
 
 

--- a/ipyparallel/tests/test_magics.py
+++ b/ipyparallel/tests/test_magics.py
@@ -5,7 +5,6 @@ import re
 import time
 
 from IPython import get_ipython
-from IPython.core.interactiveshell import InteractiveShell
 from IPython.utils.io import capture_output
 
 import pytest
@@ -13,7 +12,6 @@ import pytest
 import ipyparallel as ipp
 from ipyparallel import AsyncResult
 
-from . import add_engines
 from .clienttest import ClusterTestCase, generate_output
 
 
@@ -241,6 +239,8 @@ class TestParallelMagics(ClusterTestCase):
         self.assertIn('\nOut[', output)
         self.assertIn(': 24690', output)
         ar = v.get_result(-1)
+        # prevent TaskAborted on pulls, due to ZeroDivisionError
+        time.sleep(0.5)
         self.assertEqual(v['a'], 5)
         self.assertEqual(v['b'], 24690)
         self.assertRaisesRemote(ZeroDivisionError, ar.get)

--- a/ipyparallel/tests/test_mongodb.py
+++ b/ipyparallel/tests/test_mongodb.py
@@ -39,7 +39,7 @@ def mongo_conn(request):
     return c
 
 
-@pytest.mark.usefixture('mongo_conn')
+@pytest.mark.usefixtures('mongo_conn')
 class TestMongoBackend(test_db.TaskDBTest, TestCase):
     """MongoDB backend tests"""
 

--- a/ipyparallel/tests/test_util.py
+++ b/ipyparallel/tests/test_util.py
@@ -1,13 +1,20 @@
 import socket
+import mock
 from ipyparallel import util
 from jupyter_client.localinterfaces import localhost, public_ips
 
 
-def test_disambiguate_ip():
+@mock.patch('warnings.warn')
+def test_disambiguate_ip(warn_mock):
     # garbage in, garbage out
     public_ip = public_ips()[0]
     assert util.disambiguate_ip_address('garbage') == 'garbage'
     assert util.disambiguate_ip_address('0.0.0.0', socket.gethostname()) == localhost()
     wontresolve = 'this.wontresolve.dns'
     assert util.disambiguate_ip_address('0.0.0.0', wontresolve) == wontresolve
+    assert warn_mock.called_once_with(
+        'IPython could not determine IPs for {}: '
+        '[Errno -2] Name or service not known'.format(wontresolve),
+        RuntimeWarning
+    )
     assert util.disambiguate_ip_address('0.0.0.0', public_ip) == localhost()

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -197,7 +197,7 @@ def is_ip(location):
     
     It could be a hostname.
     """
-    return bool(re.match(location, '(\d+\.){3}\d+'))
+    return bool(re.match(location, r'(\d+\.){3}\d+'))
 
 
 @lru_cache()

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,10 @@ setup_args = dict(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     cmdclass={
         "test": IPTestCommand,


### PR DESCRIPTION
Hello @minrk,

The main purpose of this PR is to ensure support for Python 3.7.

These changes:
 - Add language classifiers for Python 3.x into `setup.py`
 - Add python 3.7 and 3.8-dev into `.travis.yml`
 - Fix spontaneous failures of `test_autopx_blocking`
 - Fix warnings where it's possible