### PR TITLE
update mocking for latest ipykernel

### DIFF
--- a/ipyparallel/tests/test_apps.py
+++ b/ipyparallel/tests/test_apps.py
@@ -38,6 +38,11 @@ def bind_kernel(engineapp):
         app.shell_port = app.iopub_port = app.stdin_port = 0
         app._bind_socket = types.MethodType(kernelapp.IPKernelApp._bind_socket,
                                             app)
+        if hasattr(kernelapp.IPKernelApp, '_try_bind_socket'):
+            app._try_bind_socket = types.MethodType(
+                kernelapp.IPKernelApp._try_bind_socket,
+                app,
+            )
         app.transport = 'tcp'
         app.ip = 'localhost'
         app.init_heartbeat.return_value = None

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -487,7 +487,7 @@ def become_dask_worker(ip, port, nanny=False, **kwargs):
     else:
         w = Worker(ip, port, **kwargs)
     shell.user_ns['dask_worker'] = shell.user_ns['distributed_worker'] = kernel.distributed_worker = w
-    w.start(0)
+    kernel.io_loop.add_callback(w.start)
 
 
 def stop_distributed_worker():


### PR DESCRIPTION
test failure caused by updates private ipykernel api (we're mocking some private stuff we maybe shouldn't)

also found a dask api change that needed updating (2.4)