### PR TITLE
importing joblib can raise TypeError on py38

### DIFF
--- a/ipyparallel/tests/test_joblib.py
+++ b/ipyparallel/tests/test_joblib.py
@@ -12,7 +12,7 @@ try:
     import joblib
     from joblib import Parallel, delayed
     from ipyparallel.client._joblib import IPythonParallelBackend
-except ImportError:
+except (ImportError, TypeError):
     have_joblib = False
 else:
     have_joblib = True


### PR DESCRIPTION
this should allow other tests to continue on py38