### PR TITLE
Merge pull request #397 from eXaz/master

### DIFF
--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -595,10 +595,10 @@ class Hub(SessionFactory):
         triggers unregistration"""
         self.log.debug("heartbeat::handle_heart_failure(%r)", heart)
         eid = self.hearts.get(heart, None)
-        uuid = self.engines[eid].uuid
         if eid is None:
             self.log.info("heartbeat::ignoring heart failure %r (not an engine or already dead)", heart)
         else:
+            uuid = self.engines[eid].uuid
             self.unregister_engine(heart, dict(content=dict(id=eid, queue=uuid)))
 
     #----------------------- MUX Queue Traffic ------------------------------


### PR DESCRIPTION
Prevent KeyError when handeling heart failures of already shut down an engines.

In case an engine got shutdown, a last pending heartbeat can trigger the heartmonitor to register a new heart. Eventually this heart will of course fail, triggering the hubs handle_heart_failure(). When looking for the corresponding engine, we end up with eid = None and a subsequent KeyError.