### PR TITLE
Merge pull request #400 from ellert/print-helpful-errors

### DIFF
--- a/ipyparallel/tests/test_client.py
+++ b/ipyparallel/tests/test_client.py
@@ -589,12 +589,12 @@ class TestClient(ClusterTestCase):
             with mock.patch('socket.gethostname', lambda: location), \
                     pytest.warns(None) as record:  # should not trigger warning
                 c = self.connect_client()
-                assert len(record) == 0, str(record)
+                assert len(record) == 0, str([str(w) for w in record])
                 c.close()
 
     def test_local_ip_true_doesnt_trigger_warning(self):
         with mock.patch('ipyparallel.client.client.is_local_ip',
                         lambda x: True), pytest.warns(None) as record:
             c = self.connect_client()
-            assert len(record) == 0, str(record)
+            assert len(record) == 0, str([str(w) for w in record])
             c.close()


### PR DESCRIPTION
Instead of:
````
=================================== FAILURES ===================================
_____________ TestClient.test_local_ip_true_doesnt_trigger_warning _____________
self = <ipyparallel.tests.test_client.TestClient testMethod=test_local_ip_true_doesnt_trigger_warning>
    def test_local_ip_true_doesnt_trigger_warning(self):
        with mock.patch('ipyparallel.client.client.is_local_ip',
                        lambda x: True), pytest.warns(None) as record:
            c = self.connect_client()
>           assert len(record) == 0, str(record)
E           AssertionError: WarningsChecker(record=True)
E           assert 6 == 0
E             -6
E             +0
ipyparallel/tests/test_client.py:599: AssertionError
=============================== warnings summary ===============================
````
You get:
````
=================================== FAILURES ===================================
_____________ TestClient.test_local_ip_true_doesnt_trigger_warning _____________
self = <ipyparallel.tests.test_client.TestClient testMethod=test_local_ip_true_doesnt_trigger_warning>
    def test_local_ip_true_doesnt_trigger_warning(self):
        with mock.patch('ipyparallel.client.client.is_local_ip',
                        lambda x: True), pytest.warns(None) as record:
            c = self.connect_client()
>           assert len(record) == 0, str([str(w) for w in record])
E           AssertionError: ["{message : ResourceWarning('unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>'), category : 'ResourceWarning', filename : '/usr/lib/python3.7/asyncio/base_events.py', lineno : 622, line : None}", "{message : ResourceWarning('unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>'), category : 'ResourceWarning', filename : '/usr/lib/python3.7/asyncio/base_events.py', lineno : 622, line : None}", "{message : ResourceWarning('unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>'), category : 'ResourceWarning', filename : '/usr/lib/python3.7/asyncio/base_events.py', lineno : 622, line : None}", "{message : ResourceWarning('unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>'), category : 'ResourceWarning', filename : '/usr/lib/python3.7/asyncio/base_events.py', lineno : 622, line : None}", "{message : ResourceWarning('unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>'), category : 'ResourceWarning', filename : '/usr/lib/python3.7/asyncio/base_events.py', lineno : 622, line : None}", "{message : ResourceWarning('unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>'), category : 'ResourceWarning', filename : '/usr/lib/python3.7/asyncio/base_events.py', lineno : 622, line : None}", "{message : ResourceWarning('unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>'), category : 'ResourceWarning', filename : '/usr/lib/python3.7/asyncio/base_events.py', lineno : 622, line : None}"]
E           assert 7 == 0
E             -7
E             +0
ipyparallel/tests/test_client.py:599: AssertionError
=============================== warnings summary ===============================
````
which is more informative.
