### PR TITLE
Merge pull request #407 from eaton-lab/master

### DIFF
--- a/ipyparallel/apps/baseapp.py
+++ b/ipyparallel/apps/baseapp.py
@@ -124,7 +124,7 @@ class BaseParallelApplication(BaseIPythonApplication):
     @observe('cluster_id')
     def _cluster_id_changed(self, change):
         if change['new']:
-            self.name += '{}-{}'.format(self.__class__.name, change['new'])
+            self.name = '{}-{}'.format(self.__class__.name, change['new'])
         else:
             self.name = self.__class__.name
 


### PR DESCRIPTION
In the current release 6.2.5 the name "ipcluster" is stored 2X which prevents the controller from being found (e.g., `.../pid/ipclusteripcluster-test.pid` below):

```bash
(base) deren@pinky:/pinky/deren/ficus-jander$ ipcluster start --engines=Local --profile=default --cluster-id=test --n=10
2020-04-24 17:31:59.964 [IPClusterStart] Starting ipcluster with [daemon=False]
2020-04-24 17:31:59.965 [IPClusterStart] Creating pid file: /home/deren/.ipython/profile_default/pid/ipclusteripcluster-test.pid
2020-04-24 17:31:59.965 [IPClusterStart] Starting Controller with LocalControllerLauncher
2020-04-24 17:32:00.973 [IPClusterStart] Starting 10 Engines with Local
2020-04-24 17:32:31.972 [IPClusterStart] Engines appear to have started successfully
```

When I make the edit above (changed `+=` to `=`) the cluster-id is now properly written and recognized. 
```bash
2020-04-24 17:31:59.965 [IPClusterStart] Creating pid file: /home/deren/.ipython/profile_default/pid/ipcluster-test.pid
```

Maybe there is a more complicated reason for updating the cluster_id name in 6.2.5, but this quick fix works for me. Also reverting to 6.2.4 fixed the problem.