### PR TITLE
become_dask: use `scheduler.address` instead of `scheduler.ip`

### DIFF
--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1368,8 +1368,7 @@ class Client(HasTraits):
         distributed_info = reply['content']
 
         # Start a Worker on the selected engines:
-        worker_args['ip'] = distributed_info['ip']
-        worker_args['port'] = distributed_info['port']
+        worker_args['address'] = distributed_info['address']
         worker_args['nanny'] = nanny
         # set default ncores=1, since that's how an IPython cluster is typically set up.
         worker_args.setdefault('ncores', 1)
@@ -1382,7 +1381,7 @@ class Client(HasTraits):
             # For distributed pre-1.18.1
             distributed_Client = distributed.Executor
 
-        client = distributed_Client('{ip}:{port}'.format(**distributed_info))
+        client = distributed_Client('{address}'.format(**distributed_info))
 
         return client
 

--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -1477,9 +1477,10 @@ class Hub(SessionFactory):
         content = {
             'status': 'ok',
             'ip': self.distributed_scheduler.ip,
+            'address': self.distributed_scheduler.address,
             'port': self.distributed_scheduler.port,
         }
-        self.log.info("dask.distributed scheduler running at {ip}:{port}".format(**content))
+        self.log.info("dask.distributed scheduler running at {address}".format(**content))
         self.session.send(self.query, "become_dask_reply", content=content,
             parent=msg, ident=client_id,
         )

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -463,16 +463,14 @@ def int_keys(dikt):
     return dikt
 
 
-def become_dask_worker(ip, port, nanny=False, **kwargs):
+def become_dask_worker(address, nanny=False, **kwargs):
     """Task function for becoming a dask.distributed Worker
 
     Parameters
     ----------
 
-    ip: str
-        The IP address of the dask Scheduler.
-    port: int
-        The port of the dask Scheduler.
+    address: str
+        The URL of the dask Scheduler.
     **kwargs:
         Any additional keyword arguments will be passed to the Worker constructor.
     """
@@ -483,9 +481,9 @@ def become_dask_worker(ip, port, nanny=False, **kwargs):
         return
     from distributed import Worker, Nanny
     if nanny:
-        w = Nanny(ip, port, **kwargs)
+        w = Nanny(address, **kwargs)
     else:
-        w = Worker(ip, port, **kwargs)
+        w = Worker(address, **kwargs)
     shell.user_ns['dask_worker'] = shell.user_ns['distributed_worker'] = kernel.distributed_worker = w
     kernel.io_loop.add_callback(w.start)
 


### PR DESCRIPTION
`scheduler.ip` can be 0.0.0.0, which does work for local testing, but
not in a real distributed setup. I tested this locally using `distributed>=2.11`, which is the first version that works with Python 3.8 IIRC. It should also work with older versions, like down to 1.16, but I didn't test those. Tests on the real cluster system are also still pending.

I'm not sure how to best add a test case for this that fails on the previous version.

Closes #414