### PR TITLE
REVERT ME: pin down ipykernel, jupyter-client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --pre --upgrade .[test] distributed joblib codecov
+          # FIXME: pin down ipykernel, due to breaking changes
+          pip install 'ipykernel<6'
           pip install --only-binary :all: matplotlib || echo "no matplotlib"
           if [ "${{ matrix.tornado }}" != "" ]; then
             pip install tornado==${{ matrix.tornado }}


### PR DESCRIPTION
upcoming prereleases (kernel 6, client 7) break compatibility and require updates.

This should be immediately reverted once fixed.