### PR TITLE
Revert pin down ipykernel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,6 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --pre --upgrade .[test] distributed joblib codecov
-          # FIXME: pin down ipykernel, due to breaking changes
-          pip install 'ipykernel<6'
           pip install --only-binary :all: matplotlib || echo "no matplotlib"
           if [ "${{ matrix.tornado }}" != "" ]; then
             pip install tornado==${{ matrix.tornado }}


### PR DESCRIPTION
Reverts ipython/ipyparallel#448

We shouldn't be pinning ipykernel, but need to for tests to pass