### PR TITLE
DOC: reformat docstrings  + misc fixes

### DIFF
--- a/ipyparallel/apps/ipclusterapp.py
+++ b/ipyparallel/apps/ipclusterapp.py
@@ -104,7 +104,7 @@ def find_launcher_class(clsname, kind):
     """Return a launcher for a given clsname and kind.
 
     Parameters
-    ==========
+    ----------
     clsname : str
         The full name of the launcher class, either with or without the
         module path, or an abbreviation (MPI, SSH, SGE, PBS, LSF, HTCondor

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -447,7 +447,6 @@ class AsyncResult(Future):
 
         Parameters
         ----------
-
         start : one or more datetime objects (e.g. ar.submitted)
         end : one or more datetime objects (e.g. ar.received)
         start_key : callable
@@ -459,7 +458,6 @@ class AsyncResult(Future):
 
         Returns
         -------
-
         dt : float
             The time elapsed (in seconds) between the two selected timestamps.
         """
@@ -579,7 +577,6 @@ class AsyncResult(Future):
 
         Parameters
         ----------
-
         groupby : str [default: type]
             if 'type':
                 Group outputs by type (show all stdout, then all stderr, etc.):

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1185,10 +1185,9 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: int, list of ints, or 'all'
+        targets : int, list of ints, or 'all'
             The engines on which the view's magics will run
-        suffix: str [default: '']
+        suffix : str [default: '']
             The suffix, if any, for the magics.  This allows you to have
             multiple views associated with parallel magics at the same time.
 
@@ -1270,18 +1269,16 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         jobs : int, str, or list of ints and/or strs, or one or more AsyncResult objects
-                ints are indices to self.history
-                strs are msg_ids
-                default: wait on all outstanding messages
+            ints are indices to self.history
+            strs are msg_ids
+            default: wait on all outstanding messages
         timeout : float
-                a time in seconds, after which to give up.
-                default is -1, which means no timeout
+            a time in seconds, after which to give up.
+            default is -1, which means no timeout
 
         Returns
         -------
-
         True : when all msg_ids are done
         False : timeout reached, some msg_ids still outstanding
         """
@@ -1356,7 +1353,6 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         jobs : msg_id, list of msg_ids, or AsyncResult
             The jobs to be aborted
 
@@ -1405,14 +1401,13 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: list of ints or 'all' [default: all]
+        targets : list of ints or 'all' [default: all]
             Which engines to shutdown.
-        hub: bool [default: False]
+        hub : bool [default: False]
             Whether to include the Hub.  hub=True implies targets='all'.
-        block: bool [default: self.block]
+        block : bool [default: self.block]
             Whether to wait for clean shutdown replies or not.
-        restart: bool [default: False]
+        restart : bool [default: False]
             NOT IMPLEMENTED
             whether to restart engines after shutting them down.
         """
@@ -1466,22 +1461,20 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: target spec (default: all)
+        targets : target spec (default: all)
             Which engines to turn into dask workers.
-        port: int (default: random)
+        port : int (default: random)
             Which port
-        nanny: bool (default: False)
+        nanny : bool (default: False)
             Whether to start workers as subprocesses instead of in the engine process.
             Using a nanny allows restarting the worker processes via ``executor.restart``.
-        scheduler_args: dict
+        scheduler_args : dict
             Keyword arguments (e.g. ip) to pass to the distributed.Scheduler constructor.
-        **worker_args:
+        **worker_args
             Any additional keyword arguments (e.g. ncores) are passed to the distributed.Worker constructor.
 
         Returns
         -------
-
         client = distributed.Client
             A dask.distributed.Client connected to the dask cluster.
         """
@@ -1527,8 +1520,7 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: target spec (default: all)
+        targets : target spec (default: all)
             Which engines to stop dask workers on.
         """
         dview = self.direct_view(targets)
@@ -1665,10 +1657,9 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: list,slice,int,etc. [default: use all engines]
+        targets : list,slice,int,etc. [default: use all engines]
             The subset of engines across which to load-balance execution
-        kwargs: passed to LoadBalancedView
+        **kwargs : passed to LoadBalancedView
         """
         if targets == 'all':
             targets = None
@@ -1683,13 +1674,11 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: list,slice,int,etc. [default: use all engines]
+        targets : list,slice,int,etc. [default: use all engines]
             The subset of engines across which to load-balance execution
 
         Returns
         -------
-
         executor: Executor
             The Executor object
         """
@@ -1709,10 +1698,9 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: list,slice,int,etc. [default: use all engines]
+        targets : list,slice,int,etc. [default: use all engines]
             The engines to use for the View
-        kwargs: passed to DirectView
+        **kwargs : passed to DirectView
         """
         single = isinstance(targets, int)
         # allow 'all' to be lazily evaluated at each execution
@@ -1731,11 +1719,10 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
-        targets: list,slice,int,etc. [default: use all engines]
+        targets : list,slice,int,etc. [default: use all engines]
             The subset of engines across which to load-balance execution
-        is_coalescing: scheduler collects all messages from engines and returns them as one
-        kwargs: passed to BroadCastView
+        is_coalescing : scheduler collects all messages from engines and returns them as one
+        **kwargs : passed to BroadCastView
         """
         targets = self._build_targets(targets)[1]
 
@@ -1771,11 +1758,9 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         indices_or_msg_ids : integer history index, str msg_id, AsyncResult,
             or a list of same.
             The indices or msg_ids of indices to be retrieved
-
         block : bool
             Whether to wait for the result to be done
         owner : bool [default: True]
@@ -1786,10 +1771,8 @@ class Client(HasTraits):
 
         Returns
         -------
-
         AsyncResult
             A single AsyncResult object will always be returned.
-
         AsyncHubResult
             A subclass of AsyncResult that retrieves results from the Hub
 
@@ -1812,16 +1795,13 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         indices_or_msg_ids : integer history index, str msg_id, or list of either
             The indices or msg_ids of indices to be retrieved
-
         block : bool
             Whether to wait for the result to be done
 
         Returns
         -------
-
         AsyncHubResult
             A subclass of AsyncResult that retrieves results from the Hub
 
@@ -1855,7 +1835,6 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         msg_ids : list of msg_ids
             if int:
                 Passed as index to self.history for convenience.
@@ -1865,7 +1844,6 @@ class Client(HasTraits):
 
         Returns
         -------
-
         results : dict
             There will always be the keys 'pending' and 'completed', which will
             be lists of msg_ids that are incomplete or complete. If `status_only`
@@ -1952,12 +1930,11 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         targets : int/str/list of ints/strs
-                the engines whose states are to be queried.
-                default : all
+            the engines whose states are to be queried.
+            default : all
         verbose : bool
-                Whether to return lengths only, or lists of ids for each element
+            Whether to return lengths only, or lists of ids for each element
         """
         if targets == 'all':
             # allow 'all' to be evaluated on the engine
@@ -2068,15 +2045,13 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         jobs : str or list of str or AsyncResult objects
-                the msg_ids whose results should be purged.
+            the msg_ids whose results should be purged.
         targets : int/list of ints
-                The engines, by integer ID, whose entire result histories are to be purged.
+            The engines, by integer ID, whose entire result histories are to be purged.
 
         Raises
         ------
-
         RuntimeError : if any of the tasks to be purged are still outstanding.
 
         """
@@ -2117,13 +2092,12 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         jobs : str or list of str or AsyncResult objects
-                the msg_ids whose results should be forgotten.
+            the msg_ids whose results should be forgotten.
         targets : int/str/list of ints/strs
-                The targets, by int_id, whose entire history is to be purged.
+            The targets, by int_id, whose entire history is to be purged.
 
-                default : None
+            default : None
         """
         if not targets and not jobs:
             raise ValueError("Must specify at least one of `targets` and `jobs`")
@@ -2156,13 +2130,12 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         jobs : str or list of str or AsyncResult objects
-                the msg_ids whose results should be forgotten.
+            the msg_ids whose results should be forgotten.
         targets : int/str/list of ints/strs
-                The targets, by int_id, whose entire history is to be purged.
+            The targets, by int_id, whose entire history is to be purged.
 
-                default : None
+            default : None
         """
         self.purge_local_results(jobs=jobs, targets=targets)
         self.purge_hub_results(jobs=jobs, targets=targets)
@@ -2188,9 +2161,8 @@ class Client(HasTraits):
 
         Returns
         -------
-
         msg_ids : list of strs
-                list of all msg_ids, ordered by task submission time.
+            list of all msg_ids, ordered by task submission time.
         """
 
         reply = self._send_recv(self._query_stream, "history_request", content={})
@@ -2207,7 +2179,6 @@ class Client(HasTraits):
 
         Parameters
         ----------
-
         query : mongodb query dict
             The search dict. See mongodb query docs for details.
         keys : list of strs [optional]

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -378,7 +378,6 @@ class ParallelMagics(Magics):
         used, the ``targets`` attribute of the view before
         entering ``%autopx`` mode.
 
-
         Then you can do the following::
 
             In [25]: %autopx
@@ -392,7 +391,6 @@ class ParallelMagics(Magics):
             [stdout:1] 10
             [stdout:2] 10
             [stdout:3] 10
-
 
             In [27]: %autopx
             %autopx disabled

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -624,6 +624,8 @@ class DirectView(View):
             the sequences to be distributed and passed to `f`
         block : bool
             whether to wait for the result or not [default self.block]
+        track:
+            See `ParallelFunction`
 
         Returns
         -------

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -153,7 +153,6 @@ class View(HasTraits):
 
         Parameters
         ----------
-
         block : bool
             whether to wait for results
         track : bool
@@ -175,7 +174,6 @@ class View(HasTraits):
 
         Examples
         --------
-
         >>> view.track=False
         ...
         >>> with view.temp_flags(track=True):
@@ -254,18 +252,16 @@ class View(HasTraits):
 
         Parameters
         ----------
-
         jobs : int, str, or list of ints and/or strs, or one or more AsyncResult objects
-                ints are indices to self.history
-                strs are msg_ids
-                default: wait on all outstanding messages
+            ints are indices to self.history
+            strs are msg_ids
+            default: wait on all outstanding messages
         timeout : float
-                a time in seconds, after which to give up.
-                default is -1, which means no timeout
+            a time in seconds, after which to give up.
+            default is -1, which means no timeout
 
         Returns
         -------
-
         True : when all msg_ids are done
         False : timeout reached, some msg_ids still outstanding
         """
@@ -278,7 +274,6 @@ class View(HasTraits):
 
         Parameters
         ----------
-
         jobs : None, str, list of strs, optional
             if None: abort all jobs.
             else: abort specific msg_id(s).
@@ -546,13 +541,9 @@ class DirectView(View):
 
         Parameters
         ----------
-
         f : callable
-
         args : list [default: empty]
-
         kwargs : dict [default: empty]
-
         targets : target list [default: self.targets]
             where to run
         block : bool [default: self.block]
@@ -562,7 +553,6 @@ class DirectView(View):
 
         Returns
         -------
-
         if self.block is False:
             returns AsyncResult
         else:
@@ -617,25 +607,22 @@ class DirectView(View):
 
         Parameters
         ----------
-
         f : callable
             function to be mapped
-        *sequences: one or more sequences of matching length
+        *sequences : one or more sequences of matching length
             the sequences to be distributed and passed to `f`
         block : bool
             whether to wait for the result or not [default self.block]
-        track:
+        track
             See `ParallelFunction`
 
         Returns
         -------
-
-
         If block=False
-          An :class:`~ipyparallel.client.asyncresult.AsyncMapResult` instance.
-          An object like AsyncResult, but which reassembles the sequence of results
-          into a single list. AsyncMapResults can be iterated through before all
-          results are complete.
+            An :class:`~ipyparallel.client.asyncresult.AsyncMapResult` instance.
+            An object like AsyncResult, but which reassembles the sequence of results
+            into a single list. AsyncMapResults can be iterated through before all
+            results are complete.
         else
             A list, the result of ``map(f,*sequences)``
         """
@@ -658,12 +645,11 @@ class DirectView(View):
 
         Parameters
         ----------
-
         code : str
-                the code string to be executed
+            the code string to be executed
         block : bool
-                whether or not to wait until done to return
-                default: self.block
+            whether or not to wait until done to return
+            default: self.block
         """
         block = self.block if block is None else block
         targets = self.targets if targets is None else targets
@@ -695,15 +681,14 @@ class DirectView(View):
 
         Parameters
         ----------
-
         filename : str
-                The path to the file
+            The path to the file
         targets : int/str/list of ints/strs
-                the engines on which to execute
-                default : all
+            the engines on which to execute
+            default : all
         block : bool
-                whether or not to wait until done
-                default: self.block
+            whether or not to wait until done
+            default: self.block
 
         """
         with open(filename, 'r') as f:
@@ -724,7 +709,6 @@ class DirectView(View):
 
         Parameters
         ----------
-
         ns : dict
             dict of keys with which to update engine namespace(s)
         block : bool [default : self.block]
@@ -855,9 +839,7 @@ class DirectView(View):
 
         Parameters
         ----------
-
-
-        suffix: str [default: '']
+        suffix : str [default: '']
             The suffix, if any, for the magics.  This allows you to have
             multiple views associated with parallel magics at the same time.
 
@@ -1015,32 +997,27 @@ class LoadBalancedView(View):
 
         Parameters
         ----------
-
         block : bool
             whether to wait for results
         track : bool
             whether to create a MessageTracker to allow the user to
             safely edit after arrays and buffers during non-copying
             sends.
-
         after : Dependency or collection of msg_ids
             Only for load-balanced execution (targets=None)
             Specify a list of msg_ids as a time-based dependency.
             This job will only be run *after* the dependencies
             have been met.
-
         follow : Dependency or collection of msg_ids
             Only for load-balanced execution (targets=None)
             Specify a list of msg_ids as a location-based dependency.
             This job will only be run on an engine where this dependency
             is met.
-
         timeout : float/int or None
             Only for load-balanced execution (targets=None)
             Specify an amount of time (in seconds) for the scheduler to
             wait for dependencies to be met before failing with a
             DependencyTimeout.
-
         retries : int
             Number of times a task will be retried on failure.
         """
@@ -1084,23 +1061,17 @@ class LoadBalancedView(View):
 
         Parameters
         ----------
-
         f : callable
-
         args : list [default: empty]
-
         kwargs : dict [default: empty]
-
         block : bool [default: self.block]
             whether to block
         track : bool [default: self.track]
             whether to ask zmq to track the message, for safe non-copying sends
-
-        !!!!!! TODO: THE REST HERE  !!!!
+        !!!!!! TODO : THE REST HERE  !!!!
 
         Returns
         -------
-
         if self.block is False:
             returns AsyncResult
         else:
@@ -1187,10 +1158,9 @@ class LoadBalancedView(View):
 
         Parameters
         ----------
-
         f : callable
             function to be mapped
-        *sequences: one or more sequences of matching length
+        *sequences : one or more sequences of matching length
             the sequences to be distributed and passed to `f`
         block : bool [default self.block]
             whether to wait for the result or not
@@ -1209,12 +1179,11 @@ class LoadBalancedView(View):
 
         Returns
         -------
-
         if block=False
-          An :class:`~ipyparallel.client.asyncresult.AsyncMapResult` instance.
-          An object like AsyncResult, but which reassembles the sequence of results
-          into a single list. AsyncMapResults can be iterated through before all
-          results are complete.
+            An :class:`~ipyparallel.client.asyncresult.AsyncMapResult` instance.
+            An object like AsyncResult, but which reassembles the sequence of results
+            into a single list. AsyncMapResults can be iterated through before all
+            results are complete.
         else
             A list, the result of ``map(f,*sequences)``
         """

--- a/ipyparallel/controller/dependency.py
+++ b/ipyparallel/controller/dependency.py
@@ -115,7 +115,6 @@ def require(*objects, **mapping):
 
     Examples
     --------
-
     ::
 
         In [1]: @ipp.require('numpy')

--- a/ipyparallel/controller/dictdb.py
+++ b/ipyparallel/controller/dictdb.py
@@ -286,10 +286,9 @@ class DictDB(BaseDB):
 
         Parameters
         ----------
-
-        check: dict
+        check : dict
             mongodb-style query argument
-        keys: list of strs [optional]
+        keys : list of strs [optional]
             if specified, the subset of keys to extract.  msg_id will *always* be
             included.
         """

--- a/ipyparallel/controller/mongodb.py
+++ b/ipyparallel/controller/mongodb.py
@@ -112,10 +112,9 @@ class MongoDB(BaseDB):
 
         Parameters
         ----------
-
-        check: dict
+        check : dict
             mongodb-style query argument
-        keys: list of strs [optional]
+        keys : list of strs [optional]
             if specified, the subset of keys to extract.  msg_id will *always* be
             included.
         """

--- a/ipyparallel/controller/sqlitedb.py
+++ b/ipyparallel/controller/sqlitedb.py
@@ -425,10 +425,9 @@ class SQLiteDB(BaseDB):
 
         Parameters
         ----------
-
-        check: dict
+        check : dict
             mongodb-style query argument
-        keys: list of strs [optional]
+        keys : list of strs [optional]
             if specified, the subset of keys to extract.  msg_id will *always* be
             included.
         """

--- a/ipyparallel/engine/datapub.py
+++ b/ipyparallel/engine/datapub.py
@@ -29,7 +29,6 @@ class ZMQDataPublisher(Configurable):
 
         Parameters
         ----------
-
         data : dict
             The data to be published. Think of it as a namespace.
         """
@@ -55,7 +54,6 @@ def publish_data(data):
 
     Parameters
     ----------
-
     data : dict
         The data to be published. Think of it as a namespace.
     """

--- a/ipyparallel/serialize/canning.py
+++ b/ipyparallel/serialize/canning.py
@@ -118,16 +118,14 @@ class CannedObject(object):
         """can an object for safe pickling
 
         Parameters
-        ==========
-
-        obj:
+        ----------
+        obj
             The object to be canned
-        keys: list (optional)
+        keys : list (optional)
             list of attribute names that will be explicitly canned / uncanned
-        hook: callable (optional)
+        hook : callable (optional)
             An optional extra callable,
             which can do additional processing of the uncanned object.
-
         large data may be offloaded into the buffers list,
         used for zero-copy transfers.
         """

--- a/ipyparallel/serialize/serialize.py
+++ b/ipyparallel/serialize/serialize.py
@@ -99,7 +99,6 @@ def serialize_object(obj, buffer_threshold=MAX_BYTES, item_threshold=MAX_ITEMS):
 
     Parameters
     ----------
-
     obj : object
         The object to be serialized
     buffer_threshold : int
@@ -140,14 +139,11 @@ def deserialize_object(buffers, g=None):
 
     Parameters
     ----------
-
-    bufs : list of buffers/bytes
-
+    buffers : list of buffers/bytes
     g : globals to be used when uncanning
 
     Returns
     -------
-
     (newobj, bufs) : unpacked object, and the list of remaining unused buffers.
     """
     bufs = list(buffers)

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -234,10 +234,9 @@ def disambiguate_ip_address(ip, location=None):
 
     Parameters
     ----------
-
     ip : IP address
         An IP address, or the special values 0.0.0.0, or *
-    location: IP address or hostname, optional
+    location : IP address or hostname, optional
         A public IP of the target machine, or its hostname.
         If location is an IP of the current machine,
         localhost will be returned,
@@ -499,10 +498,9 @@ def become_dask_worker(address, nanny=False, **kwargs):
 
     Parameters
     ----------
-
-    address: str
+    address : str
         The URL of the dask Scheduler.
-    **kwargs:
+    **kwargs
         Any additional keyword arguments will be passed to the Worker constructor.
     """
     shell = get_ipython()


### PR DESCRIPTION
DOC: Autoreformatting to confirm to numpydoc

Many trailing space, but spaces before colon in parameters are
meaningful.

a couple of typos also.