### PR TITLE
regression tests for outstanding, engine crash

### DIFF
--- a/ipyparallel/tests/clienttest.py
+++ b/ipyparallel/tests/clienttest.py
@@ -1,6 +1,7 @@
 """base class for parallel client tests"""
 from __future__ import print_function
 
+import os
 import sys
 import time
 
@@ -25,24 +26,8 @@ def segfault():
 
 
 def crash():
-    """from stdlib crashers in the test suite"""
-    import types
-
-    if sys.platform.startswith('win'):
-        import ctypes
-
-        ctypes.windll.kernel32.SetErrorMode(0x0002)
-    args = [0, 0, 0, 0, b'\x04\x71\x00\x00', (), (), (), '', '', 1, b'']
-    if sys.version_info[0] >= 3:
-        # Python3 adds 'kwonlyargcount' as the second argument to Code
-        args.insert(1, 0)
-    if sys.version_info > (3, 8):
-        # Python 3.8 adds 'posonlyargcount' as the second argument to Code
-        # kwonlyargcount added above is now the third argument
-        args.insert(1, 0)
-
-    co = types.CodeType(*args)
-    exec(co)
+    """Ungracefully exit the process"""
+    os._exit(1)
 
 
 def wait(n):

--- a/ipyparallel/tests/test_client.py
+++ b/ipyparallel/tests/test_client.py
@@ -70,6 +70,19 @@ class TestClient(ClusterTestCase):
         self.assertEqual(v.targets, targets[-1])
         self.assertRaises(TypeError, lambda: self.client[None])
 
+    def test_outstanding(self):
+        self.minimum_engines(1)
+        e = self.client[-1]
+        engine_id = self.client._engines[e.targets]
+        ar = e.apply_async(time.sleep, 0.5)
+        msg_id = ar.msg_ids[0]
+        # verify that msg id
+        assert msg_id in self.client.outstanding
+        assert msg_id in self.client._outstanding_dict[engine_id]
+        ar.get()
+        assert msg_id not in self.client.outstanding
+        assert msg_id not in self.client._outstanding_dict[engine_id]
+
     def test_lbview_targets(self):
         """test load_balanced_view targets"""
         v = self.client.load_balanced_view()

--- a/ipyparallel/tests/test_lbview.py
+++ b/ipyparallel/tests/test_lbview.py
@@ -20,17 +20,16 @@ class TestLoadBalancedView(ClusterTestCase):
         ClusterTestCase.setUp(self)
         self.view = self.client.load_balanced_view()
 
-    @pytest.mark.xfail
-    def test_z_crash_task(self):
+    def test_z_crash(self):
         """test graceful handling of engine death (balanced)"""
-        # self.add_engines(1)
+        self.add_engines(1)
         ar = self.view.apply_async(crash)
         self.assertRaisesRemote(error.EngineError, ar.get, 10)
         eid = ar.engine_id
         tic = time.time()
         while eid in self.client.ids and time.time() - tic < 5:
             time.sleep(0.01)
-        self.assertFalse(eid in self.client.ids, "Engine should have died")
+        assert eid not in self.client.ids
 
     def test_map(self):
         def f(x):

--- a/ipyparallel/tests/test_view.py
+++ b/ipyparallel/tests/test_view.py
@@ -39,10 +39,9 @@ class TestView(ClusterTestCase):
             time.sleep(2)
         super(TestView, self).setUp()
 
-    @pytest.mark.xfail
     def test_z_crash_mux(self):
         """test graceful handling of engine death (direct)"""
-        # self.add_engines(1)
+        self.add_engines(1)
         eid = self.client.ids[-1]
         ar = self.client[eid].apply_async(crash)
         self.assertRaisesRemote(error.EngineError, ar.get, 10)
@@ -50,7 +49,7 @@ class TestView(ClusterTestCase):
         tic = time.time()
         while eid in self.client.ids and time.time() - tic < 5:
             time.sleep(0.01)
-        self.assertFalse(eid in self.client.ids, "Engine should have died")
+        assert eid not in self.client.ids
 
     def test_push_pull(self):
         """test pushing and pulling"""


### PR DESCRIPTION
these were xfail due to CI not handling the segfault nicely (especially on Windows, IIRC), but we can use `os._exit` and it should be enough.

regression tests for #452 