### PR TITLE
Basic Streaming Output Implementation

### DIFF
--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -158,6 +158,10 @@ class AsyncResult(Future):
 
         yield
 
+        # This throws a KeyError. It seems to be already cleaned up before we get here.
+        # for msg_id in self.msg_ids:
+        #     self._client._futures[msg_id].iopub_callbacks.pop()
+
     def __repr__(self):
         if self._ready:
             return "<%s: %s:finished>" % (self.__class__.__name__, self._fname)
@@ -624,6 +628,8 @@ class AsyncResult(Future):
                 plots together, then all of the second plots, and so on.
         """
         self.wait_for_output()
+        if get_ipython() is not None:
+            clear_output(wait=True)
         if self._single_result:
             self._display_single_result()
             return

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -593,17 +593,16 @@ class AsyncResult(Future):
             prefix = prefix + '\n'
         print("%s%s" % (prefix, text), file=file, end=end)
 
-    def _display_single_result(self, result_only=False):
-        if not result_only:
+    def _display_single_result(self, skip_stdout_stderr=False):
+        if not skip_stdout_stderr:
             self._display_stream(self.stdout)
             self._display_stream(self.stderr, file=sys.stderr)
         if get_ipython() is None:
             # displaypub is meaningless outside IPython
             return
 
-        if not result_only:
-            for output in self.outputs:
-                self._republish_displaypub(output, self.engine_id)
+        for output in self.outputs:
+            self._republish_displaypub(output, self.engine_id)
 
         if self.execute_result is not None:
             display(self.get())
@@ -643,7 +642,7 @@ class AsyncResult(Future):
         """
         self.wait_for_output()
         if self._single_result:
-            self._display_single_result()
+            self._display_single_result(skip_stdout_stderr=skip_stdout_stderr)
             return
 
         stdouts = self.stdout

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -134,6 +134,15 @@ class AsyncResult(Future):
         self._output_future.add_done_callback(self._resolve_output)
         self.add_done_callback(self._finalize_result)
 
+    def _enable_streaming_output(self):
+        def io_stream_callback(msg):
+            print(msg['content']['text'])  # CHANGE
+
+        for msg_id in self.msg_ids:
+            self._client._futures[msg_id].io_stream_callbacks.append(
+                io_stream_callback
+            )  # TODO
+
     def __repr__(self):
         if self._ready:
             return "<%s: %s:finished>" % (self.__class__.__name__, self._fname)

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -597,56 +597,23 @@ class AsyncResult(Future):
             prefix = prefix + '\n'
         print("%s%s" % (prefix, text), file=file, end=end)
 
-    def _display_single_result(self):
-        self._display_stream(self.stdout)
-        self._display_stream(self.stderr, file=sys.stderr)
+    def _display_single_result(self, result_only=False):
+        if not result_only:
+            self._display_stream(self.stdout)
+            self._display_stream(self.stderr, file=sys.stderr)
         if get_ipython() is None:
             # displaypub is meaningless outside IPython
             return
 
-        for output in self.outputs:
-            self._republish_displaypub(output, self.engine_id)
+        if not result_only:
+            for output in self.outputs:
+                self._republish_displaypub(output, self.engine_id)
 
         if self.execute_result is not None:
             display(self.get())
 
-    def _display_results_only_single_result(self):
-        if get_ipython() is None:
-            # displaypub is meaningless outside IPython
-            return
-        if self.execute_result is not None:
-            display(self.get())
-
     @check_ready
-    def display_results_only(self, groupby="type"):
-        self.wait_for_output()
-        if self._single_result:
-            self._display_results_only_single_result()
-            return
-        execute_results = self.execute_result
-        results = self.get()
-        targets = self.engine_id
-
-        if get_ipython() is None:
-            # displaypub is meaningless outside IPython
-            return
-
-        if groupby == "engine":
-            for eid, r, execute_result in zip(targets, results, execute_results):
-                if execute_result is not None:
-                    _raw_text('[output:%i]' % eid)
-                    display(r)
-        elif groupby in ('type', 'order'):
-            for eid, r, execute_result in zip(targets, results, execute_results):
-                if execute_result is not None:
-                    display(r)
-        else:
-            raise ValueError(
-                "groupby must be one of 'type', 'engine', 'collate', not %r" % groupby
-            )
-
-    @check_ready
-    def display_outputs(self, groupby="type"):
+    def display_outputs(self, groupby="type", result_only=False):
         """republish the outputs of the computation
 
         Parameters
@@ -672,6 +639,11 @@ class AsyncResult(Future):
                 outputs.  This is meant for cases of each command producing
                 several plots, and you would like to see all of the first
                 plots together, then all of the second plots, and so on.
+
+        result_only: boolean [default: False]
+            Only display the execution result and skip stdout, stderr,
+            and display outputs. Usually used when using streaming output
+            since these outputs would have already been displayed.
         """
         self.wait_for_output()
         if self._single_result:
@@ -690,53 +662,57 @@ class AsyncResult(Future):
             for eid, stdout, stderr, outputs, r, execute_result in zip(
                 targets, stdouts, stderrs, output_lists, results, execute_results
             ):
-                self._display_stream(stdout, '[stdout:%i] ' % eid)
-                self._display_stream(stderr, '[stderr:%i] ' % eid, file=sys.stderr)
+                if not result_only:
+                    self._display_stream(stdout, '[stdout:%i] ' % eid)
+                    self._display_stream(stderr, '[stderr:%i] ' % eid, file=sys.stderr)
 
                 if get_ipython() is None:
                     # displaypub is meaningless outside IPython
                     continue
 
-                if outputs or execute_result is not None:
+                if (outputs and not result_only) or execute_result is not None:
                     _raw_text('[output:%i]' % eid)
 
-                for output in outputs:
-                    self._republish_displaypub(output, eid)
+                if not result_only:
+                    for output in outputs:
+                        self._republish_displaypub(output, eid)
 
                 if execute_result is not None:
                     display(r)
 
         elif groupby in ('type', 'order'):
-            # republish stdout:
-            for eid, stdout in zip(targets, stdouts):
-                self._display_stream(stdout, '[stdout:%i] ' % eid)
+            if not result_only:
+                # republish stdout:
+                for eid, stdout in zip(targets, stdouts):
+                    self._display_stream(stdout, '[stdout:%i] ' % eid)
 
-            # republish stderr:
-            for eid, stderr in zip(targets, stderrs):
-                self._display_stream(stderr, '[stderr:%i] ' % eid, file=sys.stderr)
+                # republish stderr:
+                for eid, stderr in zip(targets, stderrs):
+                    self._display_stream(stderr, '[stderr:%i] ' % eid, file=sys.stderr)
 
             if get_ipython() is None:
                 # displaypub is meaningless outside IPython
                 return
 
-            if groupby == 'order':
-                output_dict = dict(
-                    (eid, outputs) for eid, outputs in zip(targets, output_lists)
-                )
-                N = max(len(outputs) for outputs in output_lists)
-                for i in range(N):
-                    for eid in targets:
-                        outputs = output_dict[eid]
-                        if len(outputs) >= N:
+            if not result_only:
+                if groupby == 'order':
+                    output_dict = dict(
+                        (eid, outputs) for eid, outputs in zip(targets, output_lists)
+                    )
+                    N = max(len(outputs) for outputs in output_lists)
+                    for i in range(N):
+                        for eid in targets:
+                            outputs = output_dict[eid]
+                            if len(outputs) >= N:
+                                _raw_text('[output:%i]' % eid)
+                                self._republish_displaypub(outputs[i], eid)
+                else:
+                    # republish displaypub output
+                    for eid, outputs in zip(targets, output_lists):
+                        if outputs:
                             _raw_text('[output:%i]' % eid)
-                            self._republish_displaypub(outputs[i], eid)
-            else:
-                # republish displaypub output
-                for eid, outputs in zip(targets, output_lists):
-                    if outputs:
-                        _raw_text('[output:%i]' % eid)
-                    for output in outputs:
-                        self._republish_displaypub(output, eid)
+                        for output in outputs:
+                            self._republish_displaypub(output, eid)
 
             # finally, add execute_result:
             for eid, r, execute_result in zip(targets, results, execute_results):

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1049,6 +1049,9 @@ class Client(HasTraits):
             name = content['name']
             s = md[name] or ''
             md[name] = s + content['text']
+            msg_future = self._futures[msg_id]
+            for callback in msg_future.io_stream_callbacks:
+                callback(msg)
         elif msg_type == 'error':
             md.update({'error': self._unwrap_exception(content)})
         elif msg_type == 'execute_input':

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1042,6 +1042,11 @@ class Client(HasTraits):
             # ignore status messages if they aren't mine
             return
 
+        # Run any callback functions
+        msg_future = self._futures[msg_id]
+        for callback in msg_future.io_stream_callbacks:
+            callback(msg)
+
         # init metadata:
         md = self.metadata[msg_id]
 
@@ -1049,9 +1054,6 @@ class Client(HasTraits):
             name = content['name']
             s = md[name] or ''
             md[name] = s + content['text']
-            msg_future = self._futures[msg_id]
-            for callback in msg_future.io_stream_callbacks:
-                callback(msg)
         elif msg_type == 'error':
             md.update({'error': self._unwrap_exception(content)})
         elif msg_type == 'execute_input':

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1042,11 +1042,6 @@ class Client(HasTraits):
             # ignore status messages if they aren't mine
             return
 
-        # Run any callback functions
-        msg_future = self._futures[msg_id]
-        for callback in msg_future.io_stream_callbacks:
-            callback(msg)
-
         # init metadata:
         md = self.metadata[msg_id]
 
@@ -1075,6 +1070,12 @@ class Client(HasTraits):
         else:
             # unhandled msg_type (status, etc.)
             pass
+
+        msg_future = self._futures.get(msg_id, None)
+        if msg_future:
+            # Run any callback functions
+            for callback in msg_future.iopub_callbacks:
+                callback(msg)
 
     def create_message_futures(self, msg_id, async_result=False, track=False):
         msg_future = MessageFuture(msg_id, track=track)

--- a/ipyparallel/client/futures.py
+++ b/ipyparallel/client/futures.py
@@ -18,7 +18,7 @@ class MessageFuture(Future):
         self.track = track
         self._tracker = None
         self.tracker = Future()
-        self.io_stream_callbacks = []
+        self.iopub_callbacks = []
         if not track:
             self.tracker.set_result(None)
         self.add_done_callback(lambda f: self._evt.set())

--- a/ipyparallel/client/futures.py
+++ b/ipyparallel/client/futures.py
@@ -18,6 +18,7 @@ class MessageFuture(Future):
         self.track = track
         self._tracker = None
         self.tracker = Future()
+        self.io_stream_callbacks = []
         if not track:
             self.tracker.set_result(None)
         self.add_done_callback(lambda f: self._evt.set())

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -337,11 +337,8 @@ class ParallelMagics(Magics):
             cm = result.stream_output() if stream_output else nullcontext()
             with cm:
                 result.get()
-            if stream_output:
-                result.display_results_only(groupby)
-            else:
-                result.display_outputs(groupby)
-
+            # Only display final execution result if streaming outputs
+            result.display_outputs(groupby, result_only=bool(stream_output))
         else:
             # return AsyncResult only on non-blocking submission
             return result

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -337,7 +337,11 @@ class ParallelMagics(Magics):
             cm = result.stream_output() if stream_output else nullcontext()
             with cm:
                 result.get()
-            result.display_outputs(groupby)
+            if stream_output:
+                result.display_results_only(groupby)
+            else:
+                result.display_outputs(groupby)
+
         else:
             # return AsyncResult only on non-blocking submission
             return result

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -336,6 +336,7 @@ class ParallelMagics(Magics):
         if block:
             cm = result.stream_output() if stream_output else nullcontext()
             with cm:
+                result.wait_for_output()
                 result.get()
             # Skip stdout/stderr if streaming stdout/stderr
             result.display_outputs(groupby, skip_stdout_stderr=bool(stream_output))

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -29,7 +29,13 @@ Usage
 from __future__ import print_function
 
 import ast
-from contextlib import nullcontext
+from contextlib import contextmanager
+
+# Python 3.6 doesn't have nullcontext, so we define our own
+@contextmanager
+def nullcontext():
+    yield
+
 
 # -----------------------------------------------------------------------------
 #  Copyright (C) 2008 The IPython Development Team
@@ -102,7 +108,7 @@ def exec_args(f):
             '--stream',
             action="store_true",
             default=True,
-            help="stream stdout/stderr in real-time",
+            help="stream stdout/stderr in real-time (only valid when using blocking execution)",
         ),
         magic_arguments.argument(
             '--no-stream',

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -178,9 +178,9 @@ def output_args(f):
             choices=['engine', 'order', 'type'],
             default='type',
             help="""Group the outputs in a particular way.
-            
+
             Choices are:
-            
+
             **type**: group outputs of all engines by type (stdout, stderr, displaypub, etc.).
             **engine**: display all output for each engine together.
             **order**: like type, but individual displaypub output from each engine is collated.
@@ -345,8 +345,8 @@ class ParallelMagics(Magics):
             with cm:
                 result.wait_for_output()
                 result.get()
-            # Skip stdout/stderr if streaming stdout/stderr
-            result.display_outputs(groupby, result_only=bool(stream_output))
+            # Skip stdout/stderr if streaming output
+            result.display_outputs(groupby, result_only=stream_output)
         else:
             # return AsyncResult only on non-blocking submission
             return result

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -106,13 +106,15 @@ def exec_args(f):
         ),
         magic_arguments.argument(
             '--stream',
-            action="store_true",
-            default=True,
+            action="store_const",
+            const=True,
+            dest='stream',
             help="stream stdout/stderr in real-time (only valid when using blocking execution)",
         ),
         magic_arguments.argument(
             '--no-stream',
-            action="store_false",
+            action="store_const",
+            const=False,
             dest='stream',
             help="do not stream stdout/stderr in real-time",
         ),
@@ -218,6 +220,8 @@ class ParallelMagics(Magics):
     last_result = None
     # verbose flag
     verbose = False
+    # streaming output flag
+    stream_ouput = True
 
     def __init__(self, shell, view, suffix=''):
         self.view = view
@@ -261,6 +265,8 @@ class ParallelMagics(Magics):
             self.view.block = args.block
         if args.set_verbose is not None:
             self.verbose = args.set_verbose
+        if args.stream is not None:
+            self.stream_ouput = args.stream
 
     @magic_arguments.magic_arguments()
     @output_args
@@ -316,6 +322,7 @@ class ParallelMagics(Magics):
 
         # defaults:
         block = self.view.block if block is None else block
+        stream_output = self.stream_ouput if stream_output is None else stream_output
 
         base = "Parallel" if block else "Async parallel"
 

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -337,8 +337,8 @@ class ParallelMagics(Magics):
             cm = result.stream_output() if stream_output else nullcontext()
             with cm:
                 result.get()
-            # Only display final execution result if streaming outputs
-            result.display_outputs(groupby, result_only=bool(stream_output))
+            # Skip stdout/stderr if streaming stdout/stderr
+            result.display_outputs(groupby, skip_stdout_stderr=bool(stream_output))
         else:
             # return AsyncResult only on non-blocking submission
             return result

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -339,7 +339,7 @@ class ParallelMagics(Magics):
                 result.wait_for_output()
                 result.get()
             # Skip stdout/stderr if streaming stdout/stderr
-            result.display_outputs(groupby, skip_stdout_stderr=bool(stream_output))
+            result.display_outputs(groupby, result_only=bool(stream_output))
         else:
             # return AsyncResult only on non-blocking submission
             return result

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import imp
 import threading
 import warnings
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 
 from decorator import decorator
 from IPython import get_ipython
@@ -108,7 +108,6 @@ class View(HasTraits):
     # flags
     block = Bool(False)
     track = Bool(False)
-    stream_output = Bool(True)
     targets = Any()
 
     history = List()
@@ -639,7 +638,7 @@ class DirectView(View):
 
     @sync_results
     @save_ids
-    def execute(self, code, silent=True, targets=None, block=None, stream_output=None):
+    def execute(self, code, silent=True, targets=None, block=None):
         """Executes `code` on `targets` in blocking or nonblocking manner.
 
         ``execute`` is always `bound` (affects engine namespace)
@@ -654,7 +653,6 @@ class DirectView(View):
         """
         block = self.block if block is None else block
         targets = self.targets if targets is None else targets
-        stream_output = self.stream_output if stream_output is None else stream_output
 
         _idents, _targets = self.client._build_targets(targets)
         futures = []
@@ -669,14 +667,12 @@ class DirectView(View):
             self.client, futures, fname='execute', targets=_targets, owner=True
         )
 
-        cm = ar.stream_output() if stream_output else nullcontext()
-        with cm:
-            if block:
-                try:
-                    ar.get()
-                    ar.wait_for_output()
-                except KeyboardInterrupt:
-                    pass
+        if block:
+            try:
+                ar.get()
+                ar.wait_for_output()
+            except KeyboardInterrupt:
+                pass
 
         return ar
 

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -666,14 +666,12 @@ class DirectView(View):
         ar = AsyncResult(
             self.client, futures, fname='execute', targets=_targets, owner=True
         )
-
         if block:
             try:
                 ar.get()
                 ar.wait_for_output()
             except KeyboardInterrupt:
                 pass
-
         return ar
 
     def run(self, filename, targets=None, block=None):

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -638,7 +638,7 @@ class DirectView(View):
 
     @sync_results
     @save_ids
-    def execute(self, code, silent=True, targets=None, block=None):
+    def execute(self, code, silent=True, targets=None, block=None, stream_output=True):
         """Executes `code` on `targets` in blocking or nonblocking manner.
 
         ``execute`` is always `bound` (affects engine namespace)
@@ -666,6 +666,8 @@ class DirectView(View):
         ar = AsyncResult(
             self.client, futures, fname='execute', targets=_targets, owner=True
         )
+        if stream_output:
+            ar._enable_streaming_output()
         if block:
             try:
                 ar.get()

--- a/ipyparallel/tests/test_magics.py
+++ b/ipyparallel/tests/test_magics.py
@@ -50,6 +50,15 @@ class TestParallelMagics(ClusterTestCase):
             for ex in expect:
                 assert re.search(ex, line) is not None, "Expected %r in %r" % (ex, line)
 
+    def _check_expected_lines_unordered(self, expected, lines):
+        for expect in expected:
+            found = False
+            for line in lines:
+                found = found | (re.search(expect, line) is not None)
+                if found:
+                    break
+            assert found, "Expected %r in output" % (expect,)
+
     def test_cellpx_block_args(self):
         """%%px --[no]block flags work"""
         ip = get_ipython()
@@ -207,8 +216,53 @@ class TestParallelMagics(ClusterTestCase):
 
     def test_cellpx_stream(self):
         """%%px --stream"""
-        # TODO
-        pass
+        ip = get_ipython()
+        v = self.client[:]
+        v.block = True
+        v.activate()
+
+        v['generate_output'] = generate_output
+
+        with capture_output(display=False) as io:
+            ip.run_cell_magic('px', '--stream', 'generate_output()')
+
+        self.assertNotIn('\n\n', io.stdout)
+        lines = io.stdout.splitlines()
+        expected = []
+        expected.extend(
+            [
+                r'\[stdout:\d+\] stdout',
+                r'\[stdout:\d+\] stdout2',
+            ]
+            * len(v)
+        )
+        expected.extend(
+            [
+                r'\[output:\d+\]',
+                r'IPython\.core\.display\.HTML',
+                r'IPython\.core\.display\.Math',
+            ]
+            * len(v)
+        )
+        expected.extend([r'Out\[\d+:\d+\]:.*IPython\.core\.display\.Math'] * len(v))
+
+        self.assertEqual(len(lines), len(expected), io.stdout)
+        # Check that all expected lines are in the output
+        self._check_expected_lines_unordered(expected, lines)
+
+        # Do the same for stderr
+        self.assertNotIn('\n\n', io.stderr)
+        lines = io.stderr.splitlines()
+        expected = []
+        expected.extend(
+            [
+                r'\[stderr:\d+\] stderr',
+                r'\[stderr:\d+\] stderr2',
+            ]
+            * len(v)
+        )
+        self.assertEqual(len(lines), len(expected), io.stderr)
+        self._check_expected_lines_unordered(expected, lines)
 
     def test_px_nonblocking(self):
         ip = get_ipython()

--- a/ipyparallel/tests/test_magics.py
+++ b/ipyparallel/tests/test_magics.py
@@ -233,13 +233,9 @@ class TestParallelMagics(ClusterTestCase):
             [
                 r'\[stdout:\d+\] stdout',
                 r'\[stdout:\d+\] stdout2',
-            ]
-            * len(v)
-        )
-        expected.extend(
-            [
                 r'\[output:\d+\]',
                 r'IPython\.core\.display\.HTML',
+                r'\[output:\d+\]',
                 r'IPython\.core\.display\.Math',
             ]
             * len(v)

--- a/ipyparallel/tests/test_magics.py
+++ b/ipyparallel/tests/test_magics.py
@@ -85,7 +85,9 @@ class TestParallelMagics(ClusterTestCase):
         v['generate_output'] = generate_output
 
         with capture_output(display=False) as io:
-            ip.run_cell_magic('px', '--group-outputs=engine', 'generate_output()')
+            ip.run_cell_magic(
+                'px', '--group-outputs=engine --no-stream', 'generate_output()'
+            )
 
         self.assertNotIn('\n\n', io.stdout)
         lines = io.stdout.splitlines()
@@ -118,7 +120,9 @@ class TestParallelMagics(ClusterTestCase):
         v['generate_output'] = generate_output
 
         with capture_output(display=False) as io:
-            ip.run_cell_magic('px', '--group-outputs=order', 'generate_output()')
+            ip.run_cell_magic(
+                'px', '--group-outputs=order --no-stream', 'generate_output()'
+            )
 
         self.assertNotIn('\n\n', io.stdout)
         lines = io.stdout.splitlines()
@@ -166,7 +170,9 @@ class TestParallelMagics(ClusterTestCase):
         v['generate_output'] = generate_output
 
         with capture_output(display=False) as io:
-            ip.run_cell_magic('px', '--group-outputs=type', 'generate_output()')
+            ip.run_cell_magic(
+                'px', '--group-outputs=type --no-stream', 'generate_output()'
+            )
 
         self.assertNotIn('\n\n', io.stdout)
         lines = io.stdout.splitlines()
@@ -198,6 +204,11 @@ class TestParallelMagics(ClusterTestCase):
                 assert re.search(ex, line) is not None, "Expected %r in %r" % (ex, line)
 
         self._check_generated_stderr(io.stderr, len(v))
+
+    def test_cellpx_stream(self):
+        """%%px --stream"""
+        # TODO
+        pass
 
     def test_px_nonblocking(self):
         ip = get_ipython()


### PR DESCRIPTION
A very basic implementation to enable streaming stdout/stderr/display-outputs.

Closes #434 (I think).

Enabled by default for blocking execution when using the `%%px` magic.