### PR TITLE
port fixed abort messages from ipykernel

### DIFF
--- a/ipyparallel/engine/kernel.py
+++ b/ipyparallel/engine/kernel.py
@@ -211,3 +211,24 @@ class IPythonParallelKernel(IPythonKernel):
         self.session.send(
             stream, 'clear_reply', ident=idents, parent=parent, content=content
         )
+
+    def _send_abort_reply(self, stream, msg, idents):
+        """Send a reply to an aborted request"""
+        # FIXME: forward-port ipython/ipykernel#684
+        self.log.info(
+            f"Aborting {msg['header']['msg_id']}: {msg['header']['msg_type']}"
+        )
+        reply_type = msg["header"]["msg_type"].rsplit("_", 1)[0] + "_reply"
+        status = {"status": "aborted"}
+        md = self.init_metadata(msg)
+        md = self.finish_metadata(msg, md, status)
+        md.update(status)
+
+        self.session.send(
+            stream,
+            reply_type,
+            metadata=md,
+            content=status,
+            parent=msg,
+            ident=idents,
+        )

--- a/ipyparallel/tests/test_view_broadcast.py
+++ b/ipyparallel/tests/test_view_broadcast.py
@@ -30,14 +30,6 @@ class TestBroadcastView(test_view.TestView):
         if not self._broadcast_view_used:
             pytest.skip("No broadcast view used")
 
-    @pytest.mark.xfail(reason="aborted replies missing metadata")
-    def test_abort(self):
-        pass
-
-    @pytest.mark.xfail(reason="aborted replies missing metadata")
-    def test_abort_all(self):
-        pass
-
     @needs_map
     def test_map(self):
         pass


### PR DESCRIPTION
and unskip affected broadcast view tests

port of https://github.com/ipython/ipykernel/pull/684