### PR TITLE
add Client.wait_for_engines(n)

### DIFF
--- a/ipyparallel/tests/clienttest.py
+++ b/ipyparallel/tests/clienttest.py
@@ -108,9 +108,7 @@ class ClusterTestCase(BaseZMQTestCase):
     def wait_on_engines(self, timeout=5):
         """wait for our engines to connect."""
         n = len(self.engines) + self.base_engine_count
-        tic = time.time()
-        while time.time() - tic < timeout and len(self.client.ids) < n:
-            time.sleep(0.1)
+        self.client.wait_for_engines(n, timeout=timeout)
 
         assert not len(self.client.ids) < n, "waiting for engines timed out"
 

--- a/ipyparallel/tests/test_client.py
+++ b/ipyparallel/tests/test_client.py
@@ -641,3 +641,13 @@ class TestClient(ClusterTestCase):
             ]
             assert len(runtime_warnings) == 0, str([str(w) for w in runtime_warnings])
             c.close()
+
+    def test_wait_for_engines(self):
+        n = len(self.client)
+        assert self.client.wait_for_engines(n) is None
+        with pytest.raises(TimeoutError):
+            self.client.wait_for_engines(n + 1, timeout=0.1)
+
+        f = self.client.wait_for_engines(n + 1, timeout=10, block=False)
+        self.add_engines(1)
+        assert f.result() is None


### PR DESCRIPTION
handy method to wait for a number of engines to be ready

While this doesn't implement the proposed *approach* in #241, this implements what I think is the right way to wait for engines to be registered.

closes #241