### PR TITLE
Add ControllerLauncher.get_connection_info

### DIFF
--- a/examples/Cluster API.ipynb
+++ b/examples/Cluster API.ipynb
@@ -39,7 +39,7 @@
     {
      "data": {
       "text/plain": [
-       "<Cluster(cluster_id='touchy-1623263478-xhlt', profile_dir='~/.ipython/profile_default')>"
+       "<Cluster(cluster_id='touchy-1623757384-cpbt', profile='default')>"
       ]
      },
      "execution_count": 1,
@@ -71,7 +71,7 @@
     {
      "data": {
       "text/plain": [
-       "<Cluster(cluster_id='touchy-1623263478-xhlt', profile_dir='~/.ipython/profile_default', controller=<running>)>"
+       "<Cluster(cluster_id='touchy-1623757384-cpbt', profile='default', controller=<running>)>"
       ]
      },
      "execution_count": 2,
@@ -100,7 +100,7 @@
     {
      "data": {
       "text/plain": [
-       "<Cluster(cluster_id='touchy-1623263478-xhlt', profile_dir='~/.ipython/profile_default', controller=<running>, engine_sets=['1623263481-w75s'])>"
+       "<Cluster(cluster_id='touchy-1623757384-cpbt', profile='default', controller=<running>, engine_sets=['1623757384-b3pm'])>"
       ]
      },
      "execution_count": 3,
@@ -138,7 +138,7 @@
     {
      "data": {
       "text/plain": [
-       "'1623263483-iafz'"
+       "'1623757385-pe8h'"
       ]
      },
      "execution_count": 4,
@@ -185,7 +185,7 @@
     }
    ],
    "source": [
-    "rc = cluster.connect_client()\n",
+    "rc = await cluster.connect_client()\n",
     "rc.wait_for_engines(6)\n",
     "rc.ids"
    ]
@@ -207,12 +207,12 @@
     {
      "data": {
       "text/plain": [
-       "{0: {'host': 'touchy', 'pid': 81944},\n",
-       " 1: {'host': 'touchy', 'pid': 81945},\n",
-       " 2: {'host': 'touchy', 'pid': 81946},\n",
-       " 3: {'host': 'touchy', 'pid': 81947},\n",
-       " 4: {'host': 'touchy', 'pid': 81952},\n",
-       " 5: {'host': 'touchy', 'pid': 81953}}"
+       "{0: {'host': 'touchy', 'pid': 24774},\n",
+       " 1: {'host': 'touchy', 'pid': 24775},\n",
+       " 2: {'host': 'touchy', 'pid': 24776},\n",
+       " 3: {'host': 'touchy', 'pid': 24762},\n",
+       " 4: {'host': 'touchy', 'pid': 24769},\n",
+       " 5: {'host': 'touchy', 'pid': 24773}}"
       ]
      },
      "execution_count": 6,
@@ -264,8 +264,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sending signal 2 to engine(s) 1623263481-w75s\n",
-      "Sending signal 2 to engine(s) 1623263483-iafz\n"
+      "Sending signal 2 to engine(s) 1623757384-b3pm\n",
+      "Sending signal 2 to engine(s) 1623757385-pe8h\n"
      ]
     },
     {
@@ -320,7 +320,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Stopping engine(s): 1623263483-iafz\n"
+      "Stopping engine(s): 1623757385-pe8h\n"
      ]
     }
    ],
@@ -346,9 +346,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Stopping engine(s): 1623263481-w75s\n",
+      "Stopping engine(s): 1623757384-b3pm\n",
       "Stopping controller\n",
-      "Controller stopped: {'exit_code': 0, 'pid': 81906}\n"
+      "Controller stopped: {'exit_code': 0, 'pid': 24758}\n"
      ]
     }
    ],
@@ -386,27 +386,19 @@
      "output_type": "stream",
      "text": [
       "Starting 4 engines with <class 'ipyparallel.cluster.launcher.LocalEngineSetLauncher'>\n",
-      "Waiting for connection file: ~/.ipython/profile_default/security/ipcontroller-touchy-1623263508-mdel-client.json\n",
-      "Stopping engine(s): 1623263508-5i4g\n",
+      "Stopping engine(s): 1623757397-ng0s\n",
       "Stopping controller\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{0: 82284, 1: 82282, 2: 82283, 3: 82285}"
+       "{0: 24989, 1: 24991, 2: 24990, 3: 24992}"
       ]
      },
      "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Controller stopped: {'exit_code': 0, 'pid': 82281}\n"
-     ]
     }
    ],
    "source": [
@@ -436,27 +428,20 @@
      "output_type": "stream",
      "text": [
       "Starting 2 engines with <class 'ipyparallel.cluster.launcher.LocalEngineSetLauncher'>\n",
-      "Waiting for connection file: ~/.ipython/profile_default/security/ipcontroller-touchy-1623263514-nqk6-client.json\n",
-      "Stopping engine(s): 1623263514-b9f9\n",
+      "Controller stopped: {'exit_code': 0, 'pid': 24988}\n",
+      "Stopping engine(s): 1623757400-5fq1\n",
       "Stopping controller\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{0: 82407, 1: 82408}"
+       "{0: 25058, 1: 25059}"
       ]
      },
      "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Controller stopped: {'exit_code': 0, 'pid': 82406}\n"
-     ]
     }
    ],
    "source": [
@@ -497,14 +482,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Controller stopped: {'exit_code': 0, 'pid': 25057}\n",
       "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n"
      ]
     }
    ],
    "source": [
+    "import os\n",
+    "os.environ[\"OMPI_MCA_rmaps_base_oversubscribe\"] = \"1\"\n",
+    "\n",
     "cluster = Cluster(n=4, engine_launcher_class='MPI')\n",
     "await cluster.start_cluster()\n",
-    "rc = cluster.connect_client()"
+    "rc = await cluster.connect_client()"
    ]
   },
   {
@@ -550,7 +539,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mTimeoutError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[0;32m/var/folders/qr/3vxfnp1x2t1fw55dr288mphc0000gn/T/ipykernel_81840/824703262.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0mar\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrc\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mapply_async\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0muhoh\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 14\u001b[0;31m \u001b[0mar\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/var/folders/qr/3vxfnp1x2t1fw55dr288mphc0000gn/T/ipykernel_24747/824703262.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0mar\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrc\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mapply_async\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0muhoh\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 14\u001b[0;31m \u001b[0mar\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;32m~/dev/ip/parallel/ipyparallel/client/asyncresult.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    227\u001b[0m                 \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexception\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    228\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 229\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTimeoutError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Result not ready.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    230\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_check_ready\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mTimeoutError\u001b[0m: Result not ready."
      ]
@@ -585,30 +574,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "ebe3e6d1-10cf-49be-83b6-da8dbaf712b1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sending signal 2 to engine(s) 1623263525-cijg\n"
-     ]
-    },
-    {
-     "ename": "TimeoutError",
-     "evalue": "Result not ready.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTimeoutError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[0;32m/var/folders/qr/3vxfnp1x2t1fw55dr288mphc0000gn/T/ipykernel_81840/3902026823.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0msignal\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mawait\u001b[0m \u001b[0mcluster\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msignal_engines\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msignal\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSIGINT\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mar\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/dev/ip/parallel/ipyparallel/client/asyncresult.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    227\u001b[0m                 \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexception\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    228\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 229\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTimeoutError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Result not ready.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    230\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_check_ready\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTimeoutError\u001b[0m: Result not ready."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import signal\n",
     "await cluster.signal_engines(signal.SIGINT)\n",
@@ -627,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "2ae1cb50-965b-400e-b39f-4567df667da2",
    "metadata": {},
    "outputs": [
@@ -635,9 +604,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Stopping engine(s): 1623263525-cijg\n",
-      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
-      "engine set stopped 1623263525-cijg: {'exit_code': -9, 'pid': 82790}\n"
+      "Stopping engine(s): 1623757404-oexv\n",
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n"
      ]
     }
    ],
@@ -647,19 +615,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "c676323b-1bf7-4983-8139-5b085c2fdf91",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[4, 5, 6, 7]"
+       "[0, 1, 2, 3]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "engine set stopped 1623757404-oexv: {'exit_code': -9, 'pid': 25078}\n"
+     ]
     }
    ],
    "source": [
@@ -678,17 +653,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "7e261d39-0793-4207-813a-24caa4ec9a92",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{4: 0, 5: 3, 6: 1, 7: 2}"
+       "{4: 0, 5: 2, 6: 3, 7: 1}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -713,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "060108bb-229b-4829-bf32-0dc7d0db0345",
    "metadata": {},
    "outputs": [
@@ -721,10 +696,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Stopping engine(s): 1623263525-cijg\n",
+      "Stopping engine(s): 1623757404-oexv\n",
       "Stopping controller\n",
-      "Controller stopped: {'exit_code': 0, 'pid': 82767}\n",
-      "engine set stopped 1623263525-cijg: {'exit_code': 1, 'pid': 82998}\n"
+      "Controller stopped: {'exit_code': 0, 'pid': 25076}\n",
+      "engine set stopped 1623757404-oexv: {'exit_code': -9, 'pid': 25154}\n"
      ]
     }
    ],

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -257,14 +257,12 @@ class Client(HasTraits):
     Parameters
     ----------
 
-    url_file : str
-        The path to ipcontroller-client.json.
+    connection_info : str or dict
+        The path to ipcontroller-client.json, or a dict containing the same information.
         This JSON file should contain all the information needed to connect to a cluster,
-        and is likely the only argument needed.
-        Connection information for the Hub's registration.  If a json connector
-        file is given, then likely no further configuration is necessary.
+        and is usually the only argument needed.
         [Default: use profile]
-    profile : bytes
+    profile : str
         The name of the Cluster profile to be used to find connector information.
         If run from an IPython application, the default profile will be the same
         as the running application, otherwise it will be 'default'.
@@ -377,6 +375,8 @@ class Client(HasTraits):
 
     def __init__(
         self,
+        connection_info=None,
+        *,
         url_file=None,
         profile=None,
         profile_dir=None,
@@ -401,14 +401,19 @@ class Client(HasTraits):
             context = zmq.Context.instance()
         self._context = context
 
-        if 'url_or_file' in extra_args:
-            url_file = extra_args['url_or_file']
-            warnings.warn(
-                "url_or_file arg no longer supported, use url_file", DeprecationWarning
-            )
+        for argname in ('url_or_file', 'url_file'):
+            if argname in extra_args:
+                connection_info = extra_args[argname]
+                warnings.warn(
+                    f"{argname} arg no longer supported, use positional connection_info argument",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
-        if url_file and util.is_url(url_file):
-            raise ValueError("single urls cannot be specified, url-files must be used.")
+        if isinstance(connection_info, str) and util.is_url(connection_info):
+            raise ValueError(
+                f"single urls ({connection_info!r}) cannot be specified, url-files must be used."
+            )
 
         self._setup_profile_dir(self.profile, profile_dir, ipython_dir)
 
@@ -419,39 +424,45 @@ class Client(HasTraits):
             ]
         )
 
-        if self._cd is not None:
-            if url_file is None:
-                if not cluster_id:
-                    client_json = 'ipcontroller-client.json'
-                else:
-                    client_json = 'ipcontroller-%s-client.json' % cluster_id
-                url_file = pjoin(self._cd.security_dir, client_json)
-                short = compress_user(url_file)
-                if not os.path.exists(url_file):
-                    print("Waiting for connection file: %s" % short)
-                    waiting_time = 0.0
-                    while waiting_time < timeout:
-                        time.sleep(min(timeout - waiting_time, 1))
-                        waiting_time += 1
-                        if os.path.exists(url_file):
-                            break
-                if not os.path.exists(url_file):
-                    msg = '\n'.join(
-                        ["Connection file %r not found." % short, no_file_msg]
-                    )
-                    raise IOError(msg)
-        if url_file is None:
+        if connection_info is None and self._profile_dir is not None:
+            # default: find connection info from profile
+            if cluster_id:
+                client_json = f'ipcontroller-{cluster_id}-client.json'
+            else:
+                client_json = 'ipcontroller-client.json'
+            connection_file = pjoin(self._profile_dir.security_dir, client_json)
+            short = compress_user(connection_file)
+            if not os.path.exists(connection_file):
+                print(f"Waiting for connection file: {short}")
+                waiting_time = 0.0
+                while waiting_time < timeout:
+                    time.sleep(min(timeout - waiting_time, 1))
+                    waiting_time += 1
+                    if os.path.exists(connection_file):
+                        break
+            if not os.path.exists(connection_file):
+                msg = '\n'.join([f"Connection file {short!r} not found.", no_file_msg])
+                raise IOError(msg)
+
+            with open(connection_file) as f:
+                connection_info = json.load(f)
+
+        if connection_info is None:
             raise IOError(no_file_msg)
 
-        if not os.path.exists(url_file):
-            # Connection file explicitly specified, but not found
-            raise IOError(
-                "Connection file %r not found. Is a controller running?"
-                % compress_user(url_file)
-            )
+        if isinstance(connection_info, dict):
+            cfg = connection_info.copy()
+        else:
+            # connection_info given as path to connection file
+            connection_file = connection_info
+            if not os.path.exists(connection_file):
+                # Connection file explicitly specified, but not found
+                raise IOError(
+                    f"Connection file {compress_user(connection_file)} not found. Is a controller running?"
+                )
 
-        with open(url_file) as f:
-            cfg = json.load(f)
+            with open(connection_file) as f:
+                connection_info = cfg = json.load(f)
 
         self._task_scheme = cfg['task_scheme']
 
@@ -593,17 +604,19 @@ class Client(HasTraits):
             ipython_dir = get_ipython_dir()
         if profile_dir is not None:
             try:
-                self._cd = ProfileDir.find_profile_dir(profile_dir)
+                self._profile_dir = ProfileDir.find_profile_dir(profile_dir)
                 return
             except ProfileDirError:
                 pass
         elif profile is not None:
             try:
-                self._cd = ProfileDir.find_profile_dir_by_name(ipython_dir, profile)
+                self._profile_dir = ProfileDir.find_profile_dir_by_name(
+                    ipython_dir, profile
+                )
                 return
             except ProfileDirError:
                 pass
-        self._cd = None
+        self._profile_dir = None
 
     def __enter__(self):
         """A client can be used as a context manager

--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -427,13 +427,18 @@ class Cluster(AsyncFirst, LoggingConfigurable):
         await self.stop_engines()
         await self.stop_controller()
 
-    def connect_client(self, **client_kwargs):
+    async def connect_client(self, **client_kwargs):
         """Return a client connected to the cluster"""
         # TODO: get connect info directly from controller
         # this assumes local files exist
         from ipyparallel import Client
 
+        connection_info = self._controller.get_connection_info()
+        if inspect.isawaitable(connection_info):
+            connection_info = await connection_info
+
         return Client(
+            connection_info['client'],
             cluster=self,
             profile_dir=self.profile_dir,
             cluster_id=self.cluster_id,
@@ -446,7 +451,7 @@ class Cluster(AsyncFirst, LoggingConfigurable):
     async def __aenter__(self):
         await self.start_controller()
         await self.start_engines()
-        client = self._context_client = self.connect_client()
+        client = self._context_client = await self.connect_client()
         if self.n:
             # wait for engine registration
             await asyncio.wrap_future(
@@ -466,7 +471,7 @@ class Cluster(AsyncFirst, LoggingConfigurable):
     def __enter__(self):
         self.start_controller_sync()
         self.start_engines_sync()
-        client = self._context_client = self.connect_client()
+        client = self._context_client = self.connect_client_sync()
         if self.n:
             # wait for engine registration
             client.wait_for_engines(self.n, block=True, timeout=self.engine_timeout)

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -4,6 +4,8 @@
 # Distributed under the terms of the Modified BSD License.
 import asyncio
 import copy
+import inspect
+import json
 import logging
 import os
 import shlex
@@ -38,12 +40,13 @@ from IPython.utils.text import EvalFormatter
 from traitlets import (
     Any,
     Integer,
-    CFloat,
+    Float,
     List,
     Unicode,
     Dict,
     Instance,
     CRegExp,
+    default,
     observe,
 )
 from ipython_genutils.encoding import DEFAULT_ENCODING
@@ -101,7 +104,7 @@ class UnknownStatus(LauncherError):
 
 
 class BaseLauncher(LoggingConfigurable):
-    """An asbtraction for starting, stopping and signaling a process."""
+    """An abstraction for starting, stopping and signaling a process."""
 
     # In all of the launchers, the work_dir is where child processes will be
     # run. This will usually be the profile_dir, but may not be. any work_dir
@@ -221,6 +224,18 @@ class ClusterAppMixin(LoggingConfigurable):
     def cluster_args(self):
         return ['--profile-dir', self.profile_dir, '--cluster-id', self.cluster_id]
 
+    @property
+    def connection_files(self):
+        """Dict of connection file paths"""
+        security_dir = os.path.join(self.profile_dir, 'security')
+        name_prefix = "ipcontroller"
+        if self.cluster_id:
+            name_prefix = f"{name_prefix}-{self.cluster_id}"
+        return {
+            kind: os.path.join(security_dir, f"{name_prefix}-{kind}.json")
+            for kind in ("client", "engine")
+        }
+
 
 class ControllerLauncher(ClusterAppMixin):
     controller_cmd = List(
@@ -234,6 +249,30 @@ class ControllerLauncher(ClusterAppMixin):
         config=True,
         help="""command-line args to pass to ipcontroller""",
     )
+
+    async def get_connection_info(self):
+        """Retrieve connection info for the controller
+
+        Default implementation assumes profile_dir and cluster_id are local.
+        """
+        connection_files = self.connection_files
+        paths = list(connection_files.values())
+        self.log.debug(f"Waiting for {paths}")
+        while not all(os.path.isfile(f) for f in paths):
+            await asyncio.sleep(0.1)
+            status = self.poll()
+            if inspect.isawaitable(status):
+                status = await status
+            if status is not None:
+                raise RuntimeError(
+                    f"Controller stopped with {status} while waiting for {paths}"
+                )
+        self.log.debug(f"Loading {paths}")
+        connection_info = {}
+        for key, path in connection_files.items():
+            with open(path) as f:
+                connection_info[key] = json.load(f)
+        return connection_info
 
 
 class EngineLauncher(ClusterAppMixin):
@@ -382,7 +421,7 @@ class LocalEngineLauncher(LocalProcessLauncher, EngineLauncher):
 class LocalEngineSetLauncher(LocalEngineLauncher):
     """Launch a set of engines as regular external processes."""
 
-    delay = CFloat(
+    delay = Float(
         0.1,
         config=True,
         help="""delay (in seconds) between starting each engine after the first.
@@ -743,14 +782,22 @@ class SSHClusterLauncher(SSHLauncher, ClusterAppMixin):
     def _remote_profile_dir_default(self):
         return self._strip_home(self.profile_dir)
 
-    @observe('cluster_id')
-    def _cluster_id_changed(self, change):
-        if change['new']:
-            raise ValueError("cluster id not supported by SSH launchers")
-
     @property
     def cluster_args(self):
-        return ['--profile-dir', self.remote_profile_dir]
+        return [
+            '--profile-dir',
+            self.remote_profile_dir,
+            '--cluster-id',
+            self.cluster_id,
+        ]
+
+    @property
+    def remote_connection_files(self):
+        """Return remote paths for connection files"""
+        return {
+            key: self.remote_profile_dir + local_path[len(self.profile_dir) :]
+            for key, local_path in self.connection_files.items()
+        }
 
 
 class SSHControllerLauncher(SSHClusterLauncher, ControllerLauncher):
@@ -770,13 +817,12 @@ class SSHControllerLauncher(SSHClusterLauncher, ControllerLauncher):
     def program_args(self):
         return self.cluster_args + self.controller_args
 
+    @default("to_fetch")
     def _to_fetch_default(self):
+        to_fetch = []
         return [
-            (
-                os.path.join(self.remote_profile_dir, 'security', cf),
-                os.path.join(self.profile_dir, 'security', cf),
-            )
-            for cf in ('ipcontroller-client.json', 'ipcontroller-engine.json')
+            (self.remote_connection_files[key], local_path)
+            for key, local_path in self.connection_files.items()
         ]
 
 
@@ -797,13 +843,11 @@ class SSHEngineLauncher(SSHClusterLauncher, EngineLauncher):
     def program_args(self):
         return self.cluster_args + self.engine_args
 
+    @default("to_send")
     def _to_send_default(self):
         return [
-            (
-                os.path.join(self.profile_dir, 'security', cf),
-                os.path.join(self.remote_profile_dir, 'security', cf),
-            )
-            for cf in ('ipcontroller-client.json', 'ipcontroller-engine.json')
+            (local_path, self.remote_connection_files[key])
+            for key, local_path in self.connection_files.items()
         ]
 
 
@@ -908,15 +952,20 @@ class SSHProxyEngineSetLauncher(SSHClusterLauncher):
 
     @property
     def program_args(self):
-        return ['-n', str(self.n), '--profile-dir', self.remote_profile_dir]
+        return [
+            '-n',
+            str(self.n),
+            '--profile-dir',
+            self.remote_profile_dir,
+            '--cluster-id',
+            self.cluster_id,
+        ]
 
+    @default("to_send")
     def _to_send_default(self):
         return [
-            (
-                os.path.join(self.profile_dir, 'security', cf),
-                os.path.join(self.remote_profile_dir, 'security', cf),
-            )
-            for cf in ('ipcontroller-client.json', 'ipcontroller-engine.json')
+            (local_path, self.remote_connection_files[key])
+            for key, local_path in self.connection_files.items()
         ]
 
     def start(self, n):

--- a/ipyparallel/tests/test_cluster.py
+++ b/ipyparallel/tests/test_cluster.py
@@ -78,8 +78,7 @@ async def test_start_stop_controller(Cluster):
     assert cluster._controller is not None
     proc = cluster._controller.process
     assert proc.poll() is None
-    # TODO: wait for connection
-    with cluster.connect_client() as rc:
+    with await cluster.connect_client() as rc:
         assert rc.queue_status() == {'unassigned': 0}
 
     await cluster.stop_controller()
@@ -102,7 +101,7 @@ async def test_start_stop_engines(Cluster, engine_launcher_class):
     launcher_class = find_launcher_class(engine_launcher_class, "EngineSet")
     assert isinstance(engine_set, launcher_class)
 
-    with cluster.connect_client() as rc:
+    with await cluster.connect_client() as rc:
         rc.wait_for_engines(n, timeout=_timeout)
 
     await cluster.stop_engines(engine_set_id)
@@ -122,7 +121,7 @@ async def test_start_stop_cluster(Cluster, engine_launcher_class):
     assert controller is not None
     assert len(cluster._engine_sets) == 1
 
-    with cluster.connect_client() as rc:
+    with await cluster.connect_client() as rc:
         rc.wait_for_engines(n, timeout=_timeout)
     await cluster.stop_cluster()
     assert cluster._controller is None
@@ -134,7 +133,7 @@ async def test_signal_engines(request, Cluster, engine_launcher_class):
     cluster = Cluster(engine_launcher_class=engine_launcher_class)
     await cluster.start_controller()
     engine_set_id = await cluster.start_engines(n=3)
-    rc = cluster.connect_client()
+    rc = await cluster.connect_client()
     request.addfinalizer(rc.close)
     while len(rc) < 3:
         await asyncio.sleep(0.1)


### PR DESCRIPTION
Retrieves connection info from the controller, returns it in a dict for easier distribution to clients and engines. Default implementation is still to wait for the existing files on disk and read them.

Clients can now be constructed with a connection *dict* without having to load it from a file.

Builds on #463 

Will take a stab at distributing info to engines in a next PR, probably via environment variable (easier for PBS, MPI without shared filesystem, but require controller to finish starting before distributing, which isn't always an option).
