### PR TITLE
Fixes for ipcontroller --ip=*

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
             tornado: "5.1.1"
           - python: "3.6"
           - python: "3.7"
+            controller_ip: "*"
           - python: "3.8"
             mpi: true
           - python: "3.9"
@@ -58,6 +59,11 @@ jobs:
           path: |
             ~/conda
           key: conda
+
+      - name: Set environment variables
+        if: matrix.controller_ip
+        run: |
+          echo "IPP_CONTROLLER_IP=${{ matrix.controller_ip }}" >> $GITHUB_ENV
 
       - name: Install Python (conda) ${{ matrix.python }}
         if: matrix.mpi

--- a/ipyparallel/controller/app.py
+++ b/ipyparallel/controller/app.py
@@ -766,9 +766,18 @@ class IPController(BaseParallelApplication):
             outgoing_id1 = identity * 2 + 1
             outgoing_id2 = outgoing_id1 + 1
             is_leaf = depth == self.broadcast_scheduler_depth
+            is_root = depth == 0
+
+            # FIXME: use localhost, not client ip for internal communication
+            # this will still be localhost anyway for the most common cases
+            # of localhost or */0.0.0.0
+            in_addr = self.client_url(BroadcastScheduler.port_name, identity)
+            if not is_root:
+                # non-root schedulers connect, so they need a disambiguated url
+                in_addr = disambiguate_url(in_addr)
 
             scheduler_args = dict(
-                in_addr=self.client_url(BroadcastScheduler.port_name, identity),
+                in_addr=in_addr,
                 mon_addr=monitor_url,
                 not_addr=disambiguate_url(self.client_url('notification')),
                 reg_addr=disambiguate_url(self.client_url('registration')),

--- a/ipyparallel/engine/app.py
+++ b/ipyparallel/engine/app.py
@@ -302,7 +302,7 @@ class IPEngine(BaseParallelApplication):
         # allow hand-override of location for disambiguation
         # and ssh-server
         if 'IPEngine.location' not in self.cli_config:
-            self.loction = d['location']
+            self.location = d['location']
         if 'ssh' in d and not self.sshserver:
             self.sshserver = d.get("ssh")
 

--- a/ipyparallel/tests/__init__.py
+++ b/ipyparallel/tests/__init__.py
@@ -68,6 +68,8 @@ def setup():
         '--ping=250',
         '--dictdb',
     ]
+    if os.environ.get("IPP_CONTROLLER_IP"):
+        cp.cmd_and_args.append(f"--ip={os.environ['IPP_CONTROLLER_IP']}")
     cp.start()
     launchers.append(cp)
     tic = time.time()


### PR DESCRIPTION
- fix location typo preventing engines from connecting, introduced in #489
- fix internal connection URLs in broadcast scheduler
- run tests on CI with `--ip=*` to ensure this is covered

closes #496