### PR TITLE
recommend wait_for_engines() in NoEnginesRegistered message

### DIFF
--- a/ipyparallel/error.py
+++ b/ipyparallel/error.py
@@ -51,7 +51,13 @@ class EngineError(KernelError):
 
 
 class NoEnginesRegistered(KernelError):
-    pass
+    """Exception for operations that require some engines, but none exist"""
+
+    def __str__(self):
+        return (
+            "This operation requires engines."
+            " Try client.wait_for_engines(n) to wait for engines to register."
+        )
 
 
 class TaskAborted(KernelError):


### PR DESCRIPTION
Improves error message when something requires engines and none are available, including recommended course of action:

```python
In [3]: rc[:]
...
NoEnginesRegistered: This operation requires engines. Try client.wait_for_engines(n) to wait for engines to register.
```

Related to #496