### PR TITLE
Add AsyncResult.get(return_exceptions=True), map(return_exceptions=True)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,7 +117,7 @@ exclude_patterns = ['winhpc.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-# default_role = None
+default_role = 'literal'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/docs/source/tutorial/asyncresult.rst
+++ b/docs/source/tutorial/asyncresult.rst
@@ -4,31 +4,36 @@
 The AsyncResult object
 ======================
 
-In non-blocking mode, :meth:`apply` submits the command to be executed and
-then returns a :class:`~.AsyncResult` object immediately. The
-AsyncResult object gives you a way of getting a result at a later
+In non-blocking mode, :meth:`~.View.apply`, :meth:`~.View.map`, and friends
+submit the command to be executed and then return an :class:`~.AsyncResult` object immediately.
+The AsyncResult object gives you a way of getting a result at a later
 time through its :meth:`get` method, but it also collects metadata
 on execution.
 
 
-Beyond multiprocessing's AsyncResult
+Beyond stdlib AsyncResult and Future
 ====================================
 
-.. Note::
+The :class:`AsyncResult` is a subclass of :py:class:`concurrent.futures.Future`.
+This means it can be integrated into existing async workflows,
+with e.g. :py:func:`asyncio.wrap_future`.
+It also extends the :py:class:`~.multiprocessing.AsyncResult` API.
 
-    The :class:`~.AsyncResult` object provides a superset of the interface in
-    :py:class:`multiprocessing.pool.AsyncResult`.  See the
-    `official Python documentation <https://docs.python.org/library/multiprocessing#multiprocessing.pool.AsyncResult>`_
-    for more on the basics of this interface.
 
-Our AsyncResult objects add a number of convenient features for working with
-parallel results, beyond what is provided by the original AsyncResult.
+.. seealso::
+
+    - :py:class:`multiprocessing.AsyncResult` API
+    - :py:class:`concurrent.futures.Future` API
+
+In addition to these common features,
+our AsyncResult objects add a number of convenient methods for working with parallel results,
+beyond what is provided by the standard library classes on which they are based.
 
 
 get_dict
 --------
 
-First, is :meth:`.AsyncResult.get_dict`, which pulls results as a dictionary
+:meth:`.AsyncResult.get_dict` pulls results as a dictionary,
 keyed by engine_id, rather than a flat list.  This is useful for quickly
 coordinating or distributing information about all of the engines.
 
@@ -48,7 +53,7 @@ as in IPython's :file:`examples/parallel/interengine` examples.
 Metadata
 ========
 
-ipyparallel tracks some metadata about the tasks, which is stored
+IPython Parallel tracks some metadata about the tasks, which is stored
 in the :attr:`.Client.metadata` dict.  The AsyncResult object gives you an
 interface for this information as well, including timestamps stdout/err,
 and engine IDs.
@@ -111,9 +116,9 @@ That is to say, if you treat an AsyncMapResult as if it were a list of your actu
 results, it should behave as you would expect, with the only difference being
 that you can start iterating through the results before they have even been computed.
 
-This lets you do a dumb version of map/reduce with the builtin Python functions,
+This lets you do a simple version of map/reduce with the builtin Python functions,
 and the only difference between doing this locally and doing it remotely in parallel
-is using the asynchronous view.map instead of the builtin map.
+is using the asynchronous ``view.map`` instead of the builtin ``map``.
 
 
 Here is a simple one-line RMS (root-mean-square) implemented with Python's builtin map/reduce.

--- a/docs/source/tutorial/direct.rst
+++ b/docs/source/tutorial/direct.rst
@@ -20,7 +20,7 @@ controller and four IPython engines. The simplest way of doing this is to use
 the :command:`ipcluster` command::
 
     $ ipcluster start -n 4
-    
+
 For more detailed information about starting the controller and engines, see
 our :ref:`introduction <parallel_overview>` to using IPython for parallel computing.
 
@@ -46,7 +46,7 @@ file to the client machine, or enter its contents as arguments to the Client con
     In [2]: rc = ipp.Client('/path/to/ipcontroller-client.json')
     # or to connect with a specific profile you have set up:
     In [3]: rc = ipp.Client(profile='mpi')
-    
+
 
 To make sure there are engines connected to the controller, users can get a list
 of engine ids:
@@ -83,13 +83,13 @@ Parallel map
 Python's builtin :func:`map` functions allows a function to be applied to a
 sequence element-by-element. This type of code is typically trivial to
 parallelize. In fact, since IPython's interface is all about functions anyway,
-you can use the builtin :func:`map` with a :class:`RemoteFunction`, or a 
+you can use the builtin :func:`map` with a :class:`RemoteFunction`, or a
 DirectView's :meth:`map` method:
 
 .. sourcecode:: ipython
 
     In [62]: serial_result = list(map(lambda x:x**10, range(32)))
-    
+
     In [63]: parallel_result = dview.map_sync(lambda x: x**10, range(32))
 
     In [64]: serial_result == parallel_result
@@ -102,7 +102,7 @@ DirectView's :meth:`map` method:
     :class:`LoadBalancedView`.
 
 .. seealso::
-    
+
     :meth:`map` is implemented via :class:`ParallelFunction`.
 
 Calling Python functions
@@ -214,14 +214,14 @@ This allows you to quickly submit long running commands without blocking your
 local IPython session:
 
 .. sourcecode:: ipython
-    
+
     # define our function
     In [6]: def wait(t):
       ....:     import time
       ....:     tic = time.time()
       ....:     time.sleep(t)
       ....:     return time.time()-tic
-    
+
     # In non-blocking mode
     In [7]: ar = dview.apply_async(wait, 2)
 
@@ -235,7 +235,7 @@ local IPython session:
     # Poll to see if the result is ready
     In [10]: ar.ready()
     Out[10]: False
-    
+
     # ask for the result, but wait a maximum of 1 second:
     In [45]: ar.get(1)
     ---------------------------------------------------------------------------
@@ -247,7 +247,7 @@ local IPython session:
          62                 raise self._exception
          63         else:
     ---> 64             raise error.TimeoutError("Result not ready.")
-         65 
+         65
          66     def ready(self):
 
     TimeoutError: Result not ready.
@@ -256,7 +256,7 @@ local IPython session:
 
     Note the import inside the function. This is a common model, to ensure
     that the appropriate modules are imported where the task is run. You can
-    also manually import modules into the engine(s) namespace(s) via 
+    also manually import modules into the engine(s) namespace(s) via
     ``view.execute('import numpy')``.
 
 Often, it is desirable to wait until a set of :class:`AsyncResult` objects
@@ -292,13 +292,13 @@ arguments are not provided. Thus the following logic is used for :attr:`block` a
 * If no keyword argument is provided, the instance attributes are used.
 * The Keyword arguments, if provided overrides the instance attributes for
   the duration of a single call.
-  
+
 The following examples demonstrate how to use the instance attributes:
 
 .. sourcecode:: ipython
 
     In [16]: dview.targets = [0,2]
-    
+
     In [17]: dview.block = False
 
     In [18]: ar = dview.apply(lambda : 10)
@@ -307,7 +307,7 @@ The following examples demonstrate how to use the instance attributes:
     Out[19]: [10, 10]
 
     In [20]: dview.targets = rc.ids # all engines (4)
-    
+
     In [21]: dview.block = True
 
     In [22]: dview.apply(lambda : 42)
@@ -347,7 +347,7 @@ Here are some examples of how you use :meth:`push` and :meth:`pull`:
 
     In [41]: dview.pull(('a', 'b'))
     Out[41]: [ [1.03234, 3453], [1.03234, 3453], [1.03234, 3453], [1.03234, 3453] ]
-    
+
     In [42]: dview.push(dict(c='speed'))
     Out[42]: [None, None, None, None]
 
@@ -421,7 +421,7 @@ The first is ``@remote``, which calls the function on every engine of a view.
        ....: def getpid():
        ....:     import os
        ....:     return os.getpid()
-       ....: 
+       ....:
 
     In [11]: getpid()
     Out[11]: [12345, 12346, 12347, 12348]
@@ -432,17 +432,17 @@ operations and distribute them, reconstructing the result.
 .. sourcecode:: ipython
 
     In [12]: import numpy as np
-    
+
     In [13]: A = np.random.random((64,48))
-    
+
     In [14]: @dview.parallel(block=True)
        ....: def pmul(A,B):
        ....:     return A*B
-    
+
     In [15]: C_local = A*A
-    
+
     In [16]: C_remote = pmul(A,A)
-    
+
     In [17]: (C_local == C_remote).all()
     Out[17]: True
 
@@ -515,7 +515,7 @@ sync_imports also takes a `local` boolean flag that defaults to True, which spec
 whether the local imports should also be performed.  However, support for `local=False`
 has not been implemented, so only packages that can be imported locally will work
 this way. Note that the usual renaming of the import handle in the same line like in
-`import matplotlib.pyplot as plt` does not work on the remote engine, the `as plt` is 
+`import matplotlib.pyplot as plt` does not work on the remote engine, the `as plt` is
 ignored remotely, while it executes locally. One could rename the remote handle with
 `%px plt = pyplot` though after the import.
 
@@ -532,7 +532,7 @@ be collected and raise a CompositeError, as demonstrated in the next section.
        ....: def findall(pat, x):
        ....:     # re is guaranteed to be available
        ....:     return re.findall(pat, x)
-          
+
     # you can also pass modules themselves, that you already have locally:
     In [71]: @ipp.require(time)
        ....: def wait(t):
@@ -562,27 +562,27 @@ more other exceptions. Here is how it works:
 .. sourcecode:: ipython
 
     In [78]: dview.block = True
-    
+
     In [79]: dview.execute("1/0")
-    [0:execute]: 
+    [0:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
 
-    [1:execute]: 
+    [1:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
 
-    [2:execute]: 
+    [2:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
 
-    [3:execute]: 
+    [3:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
@@ -598,8 +598,8 @@ If you want, you can even raise one of these original exceptions:
        ....:     dview.execute('1/0', block=True)
        ....: except ipp.CompositeError as e:
        ....:     e.raise_exception()
-       ....: 
-       ....: 
+       ....:
+       ....:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
@@ -611,42 +611,42 @@ these :exc:`CompositeError` exceptions is raised and inspect the exception:
 .. sourcecode:: ipython
 
     In [81]: dview.execute('1/0')
-    [0:execute]: 
+    [0:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
 
-    [1:execute]: 
+    [1:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
 
-    [2:execute]: 
+    [2:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
 
-    [3:execute]: 
+    [3:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
-    
+
     In [82]: %debug
     > /.../site-packages/IPython/parallel/client/asyncresult.py(125)get()
         124             else:
     --> 125                 raise self._exception
         126         else:
-    
+
     # Here, self._exception is the CompositeError instance:
-    
+
     ipdb> e = self._exception
     ipdb> e
     CompositeError(4)
-    
+
     # we can tab-complete on e to see available methods:
     ipdb> e.<TAB>
     e.args               e.message            e.traceback
@@ -654,10 +654,10 @@ these :exc:`CompositeError` exceptions is raised and inspect the exception:
     e.ename              e.print_traceback
     e.engine_info        e.raise_exception
     e.evalue             e.render_traceback
-    
+
     # We can then display the individual tracebacks, if we want:
     ipdb> e.print_traceback(1)
-    [1:execute]: 
+    [1:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
@@ -674,7 +674,7 @@ You can change this limit to suit your needs with:
 
     In [21]: ipp.CompositeError.tb_limit = 1
     In [22]: %px x=z
-    [0:execute]: 
+    [0:execute]:
     ---------------------------------------------------------------------------
     NameError                                 Traceback (most recent call last)
     ----> 1 x=z
@@ -692,10 +692,30 @@ All of this same error handling magic works the same in non-blocking mode:
     In [84]: ar = dview.execute('1/0')
 
     In [85]: ar.get()
-    [0:execute]: 
+    [0:execute]:
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     ----> 1 1/0
     ZeroDivisionError: integer division or modulo by zero
-    
+
     ... 3 more exceptions ...
+
+
+Sometimes you still want to get the successful subset, even when there was an error.
+Like :py:func:`asyncio.gather`, :meth:`.AsyncResult.get` and map functions accept a `return_exception` argument
+(new in IPython Parallel 7.0),
+to return the Exception objects among results instead of raising the first error encountered.
+
+.. sourcecode:: ipython
+
+    In [89]: ar = dview.apply_async(lambda: 1/0)
+    In [90]: ar.get(return_exceptions=True)
+    Out[90]:
+    [<Remote[0]:ZeroDivisionError(division by zero)>,
+     <Remote[1]:ZeroDivisionError(division by zero)>,
+     <Remote[2]:ZeroDivisionError(division by zero)>,
+     <Remote[3]:ZeroDivisionError(division by zero)>]
+
+
+.. versionadded:: 7.0
+  The `return_exceptions` feature

--- a/ipyparallel/client/remotefunction.py
+++ b/ipyparallel/client/remotefunction.py
@@ -186,6 +186,7 @@ class ParallelFunction(RemoteFunction):
     ordered : bool [default: True]
         Whether the result should be kept in order. If False,
         results become available as they arrive, regardless of submission order.
+    return_exceptions : bool [default: False]
     **flags
         remaining kwargs are passed to View.temp_flags
     """
@@ -195,11 +196,20 @@ class ParallelFunction(RemoteFunction):
     mapObject = None
 
     def __init__(
-        self, view, f, dist='b', block=None, chunksize=None, ordered=True, **flags
+        self,
+        view,
+        f,
+        dist='b',
+        block=None,
+        chunksize=None,
+        ordered=True,
+        return_exceptions=False,
+        **flags,
     ):
         super(ParallelFunction, self).__init__(view, f, block=block, **flags)
         self.chunksize = chunksize
         self.ordered = ordered
+        self.return_exceptions = return_exceptions
 
         mapClass = Map.dists[dist]
         self.mapObject = mapClass()
@@ -296,6 +306,7 @@ class ParallelFunction(RemoteFunction):
             self.mapObject,
             fname=getname(self.func),
             ordered=self.ordered,
+            return_exceptions=self.return_exceptions,
         )
 
         if self.block:

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -600,15 +600,16 @@ class DirectView(View):
         return ar
 
     @sync_results
-    def map(self, f, *sequences, **kwargs):
-        """``view.map(f, *sequences, block=self.block)`` => list|AsyncMapResult
-
-        Parallel version of builtin `map`, using this View's `targets`.
+    def map(self, f, *sequences, block=None, track=False, return_exceptions=False):
+        """Parallel version of builtin `map`, using this View's `targets`.
 
         There will be one task per target, so work will be chunked
         if the sequences are longer than `targets`.
 
         Results can be iterated as they are ready, but will become available in chunks.
+
+        .. versionadded:: 7.0
+            `return_exceptions`
 
         Parameters
         ----------
@@ -616,10 +617,13 @@ class DirectView(View):
             function to be mapped
         *sequences : one or more sequences of matching length
             the sequences to be distributed and passed to `f`
-        block : bool
-            whether to wait for the result or not [default self.block]
-        track
-            See `ParallelFunction`
+        block : bool [default self.block]
+            whether to wait for the result or not
+        track : bool [default False]
+            Track underlying zmq send to indicate when it is safe to modify memory.
+            Only for zero-copy sends such as numpy arrays that are going to be modified in-place.
+        return_exceptions : bool [default False]
+            Return remote Exceptions in the result sequence instead of raising them.
 
         Returns
         -------
@@ -632,13 +636,13 @@ class DirectView(View):
             A list, the result of ``map(f,*sequences)``
         """
 
-        block = kwargs.pop('block', self.block)
-        for k in kwargs.keys():
-            if k not in ['block', 'track']:
-                raise TypeError("invalid keyword arg, %r" % k)
+        if block is None:
+            block = self.block
 
         assert len(sequences) > 0, "must have some sequences to map onto!"
-        pf = ParallelFunction(self, f, block=block, **kwargs)
+        pf = ParallelFunction(
+            self, f, block=block, track=track, return_exceptions=return_exceptions
+        )
         return pf.map(*sequences)
 
     @sync_results
@@ -1227,11 +1231,12 @@ class LoadBalancedView(View):
     ):
         """Parallel version of builtin `map`, load-balanced by this View.
 
-        `block`, and `chunksize` can be specified by keyword only.
-
         Each `chunksize` elements will be a separate task, and will be
         load-balanced. This lets individual elements be available for iteration
         as soon as they arrive.
+
+        .. versionadded:: 7.0
+            `return_exceptions`
 
         Parameters
         ----------
@@ -1302,7 +1307,7 @@ class LoadBalancedView(View):
         and avoid potentially expensive read-ahead for large streams of inputs
         that may not fit in memory all at once.
 
-        .. versionadded: 7.0
+        .. versionadded:: 7.0
 
         Parameters
         ----------

--- a/ipyparallel/tests/clienttest.py
+++ b/ipyparallel/tests/clienttest.py
@@ -137,7 +137,7 @@ class ClusterTestCase(BaseZMQTestCase):
 
     def client_wait(self, client, jobs=None, timeout=-1):
         """my wait wrapper, sets a default finite timeout to avoid hangs"""
-        if timeout < 0:
+        if timeout is None or timeout < 0:
             timeout = self.timeout
         return Client.wait(client, jobs, timeout)
 

--- a/ipyparallel/tests/test_lbview.py
+++ b/ipyparallel/tests/test_lbview.py
@@ -204,6 +204,23 @@ class TestLoadBalancedView(ClusterTestCase):
         # verify that max_outstanding wasn't exceeded
         assert 4 <= len(self.view.history) <= 6
 
+    def test_imap_return_exceptions(self):
+        view = self.view
+
+        source = count()
+
+        def fail_on_even(n):
+            if n % 2 == 0:
+                raise ValueError("even!")
+            return n
+
+        gen = view.imap(fail_on_even, range(5), return_exceptions=True)
+        for i, r in enumerate(gen):
+            if i % 2 == 0:
+                assert isinstance(r, error.RemoteError)
+            else:
+                assert r == i
+
     def test_abort(self):
         view = self.view
         ar = self.client[:].apply_async(time.sleep, 0.5)


### PR DESCRIPTION
Allows exceptions to be returned instead of raised

so that partial errors can be handled and successful values from partial success extracted

closes #234