### PR TITLE
docs tweaks

### DIFF
--- a/docs/source/api/ipyparallel.rst
+++ b/docs/source/api/ipyparallel.rst
@@ -12,34 +12,45 @@ Classes
 -------
 
 .. autoclass:: Cluster
+    :inherited-members:
 
 .. autoclass:: Client
+    :inherited-members:
 
 .. autoclass:: DirectView
+    :inherited-members:
 
 .. autoclass:: LoadBalancedView
+    :inherited-members:
 
 .. autoclass:: BroadcastView
+    :inherited-members:
+
+.. autoclass:: AsyncResult
+    :inherited-members:
 
 .. autoclass:: ViewExecutor
+    :inherited-members:
 
 Decorators
 ----------
 
 IPython parallel provides some decorators to assist in using your functions as tasks.
 
-.. autofunction:: interactive
-.. autofunction:: require
-.. autofunction:: depend
-.. autofunction:: remote
-.. autofunction:: parallel
+.. autodecorator:: interactive
+.. autodecorator:: require
+.. autodecorator:: depend
+.. autodecorator:: remote
+.. autodecorator:: parallel
 
 
 Exceptions
 ----------
 
 .. autoexception:: RemoteError
+    :no-members:
 .. autoexception:: CompositeError
+    :no-members:
 .. autoexception:: NoEnginesRegistered
 .. autoexception:: ImpossibleDependency
 .. autoexception:: InvalidDependency

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,6 @@ from traitlets.config import LoggingConfigurable
 # exclude members inherited from HasTraits by default
 autodoc_default_options = {
     'members': None,
-    "inherited-members": None,
     "exclude-members": ','.join(dir(LoggingConfigurable)),
 }
 

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -369,7 +369,10 @@ class AsyncResult(Future):
         return self.get_dict(0)
 
     def abort(self):
-        """abort my tasks."""
+        """Abort my tasks, if possible.
+
+        Only tasks that have not started yet can be aborted.
+        """
         assert not self.ready(), "Can't abort, I am already done!"
         return self._client.abort(self.msg_ids, targets=self._targets, block=True)
 

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1516,6 +1516,10 @@ class Client(HasTraits):
 
         This is a mechanism to prevent jobs that have already been submitted
         from executing.
+        To halt a running job,
+        you must interrupt the engine(s) by sending a signal.
+        This can be done via os.kill for local engines,
+        or :meth:`.Cluster.signal_engines` for multiple engines.
 
         Parameters
         ----------

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -269,6 +269,10 @@ class View(HasTraits):
     def abort(self, jobs=None, targets=None, block=None):
         """Abort jobs on my engines.
 
+        Note: only jobs that have not started yet can be aborted.
+        To halt a running job,
+        you must interrupt the engine(s) via the Cluster API.
+
         Parameters
         ----------
         jobs : None, str, list of strs, optional


### PR DESCRIPTION
- ensure AsyncResult API is in docs
- use autodecorator for decorators instead of autofunction
- tweak which classes document inherited members
- more detail in abort docstrings about when it can be used closes #506 