### PR TITLE
Fixes and tests for SSHProxy

### DIFF
--- a/ipyparallel/cluster/app.py
+++ b/ipyparallel/cluster/app.py
@@ -316,10 +316,10 @@ class IPClusterEngines(BaseParallelApplication):
 
     async def start_engines(self):
         try:
-            await self.cluster.start_engines(self.n)
+            await self.cluster.start_engines()
         except:
             self.log.exception("Engine start failed")
-            raise
+            self.exit(1)
 
         if self.daemonize:
             self.loop.add_callback(self.loop.stop)

--- a/ipyparallel/cluster/app.py
+++ b/ipyparallel/cluster/app.py
@@ -10,6 +10,7 @@ import os
 import re
 import signal
 import sys
+from functools import partial
 
 import zmq
 from IPython.core.profiledir import ProfileDir
@@ -308,7 +309,28 @@ class IPClusterEngines(BaseParallelApplication):
 
     def init_signal(self):
         # Setup signals
+        for signame in ("SIGUSR1", "SIGUSR2", "SIGINFO"):
+            try:
+                signum = getattr(signal, signame)
+            except AttributeError:
+                self.log.debug(f"Not forwarding {signame}")
+                pass
+            else:
+                self.log.debug(f"Forwarding {signame} to engines")
+                signal.signal(signum, self.relay_signal)
         signal.signal(signal.SIGINT, self.sigint_handler)
+        signal.signal(signal.SIGTERM, self.sigint_handler)
+
+    def relay_signal(self, signum, frame):
+        self.log.debug(f"Received signal {signum} received, relaying to engines...")
+        self.loop.add_callback_from_signal(partial(self.cluster.signal_engines, signum))
+
+    def sigint_handler(self, signum, frame):
+        return self.relay_signal(signum, frame)
+
+    def sigterm_handler(self, signum, frame):
+        self.log.debug(f"Received signal {signum} received, stopping launchers...")
+        self.loop.add_callback_from_signal(self.stop_cluster)
 
     def engines_started_ok(self):
         self.log.info("Engines appear to have started successfully")
@@ -373,10 +395,6 @@ class IPClusterEngines(BaseParallelApplication):
             self.log.error("IPython cluster: stopping")
             await self.cluster.stop_cluster()
             self.loop.add_callback(self.loop.stop)
-
-    def sigint_handler(self, signum, frame):
-        self.log.debug("SIGINT received, stopping launchers...")
-        self.loop.add_callback_from_signal(self.stop_cluster)
 
     def start_logging(self):
         # Remove old log files of the controller and engine
@@ -462,6 +480,11 @@ class IPClusterStart(IPClusterEngines):
         if not self._stopping:
             self.log.warning("Controller stopped. Shutting down.")
             self.loop.add_callback(self.stop_cluster)
+
+    def sigint_handler(self, signum, frame):
+        """Unlike engines, SIGINT shuts down `ipcluster start`"""
+        self.log.debug(f"Received signal {signum} received, stopping launchers...")
+        self.loop.add_callback_from_signal(self.stop_cluster)
 
     def start(self):
         """Start the app for the start subcommand."""

--- a/ipyparallel/tests/test_ssh.py
+++ b/ipyparallel/tests/test_ssh.py
@@ -12,12 +12,13 @@ from .test_cluster import test_to_from_dict  # noqa: F401
 # import tests that use engine_launcher_class fixture
 
 
-@pytest.fixture
-def ssh_config(ssh_key):
+@pytest.fixture(params=["SSH", "SSHProxy"])
+def ssh_config(ssh_key, request):
     c = Config()
     c.Cluster.controller_ip = '0.0.0.0'
-    c.Cluster.engine_launcher_class = 'SSH'
-    c.SSHEngineSetLauncher.scp_args = c.SSHLauncher.ssh_args = [
+    c.Cluster.engine_launcher_class = request.param
+    engine_set_cfg = c[f"{request.param}EngineSetLauncher"]
+    engine_set_cfg.ssh_args = [
         "-o",
         "UserKnownHostsFile=/dev/null",
         "-o",
@@ -25,10 +26,15 @@ def ssh_config(ssh_key):
         "-i",
         ssh_key,
     ]
+    engine_set_cfg.scp_args = list(engine_set_cfg.ssh_args)  # copy
+    engine_set_cfg.remote_python = "/opt/conda/bin/python3"
+    engine_set_cfg.remote_profile_dir = "/home/ciuser/.ipython/profile_default"
+    engine_set_cfg.engine_args = ['--debug']
+    c.SSHProxyEngineSetLauncher.hostname = "127.0.0.1"
+    c.SSHProxyEngineSetLauncher.ssh_args.append("-p2222")
+    c.SSHProxyEngineSetLauncher.scp_args.append("-P2222")
+    c.SSHProxyEngineSetLauncher.user = "ciuser"
     c.SSHEngineSetLauncher.engines = {"ciuser@127.0.0.1:2222": 4}
-    c.SSHEngineSetLauncher.remote_python = "/opt/conda/bin/python3"
-    c.SSHEngineSetLauncher.remote_profile_dir = "/home/ciuser/.ipython/profile_default"
-    c.SSHEngineSetLauncher.engine_args = ['--debug']
     return c
 
 
@@ -41,4 +47,4 @@ def Cluster(ssh_config, BaseCluster):  # noqa: F811
 # override engine_launcher_class
 @pytest.fixture
 def engine_launcher_class(ssh_config):
-    return 'SSH'
+    return ssh_config.Cluster.engine_launcher_class


### PR DESCRIPTION
- ipcluster engines exits when engines exit
- ipcluster engines forwards signals by default
- call `ipython profile create` remotely for remote_profile_dir to ensure subdirectories exist
- expose ipclsuter_args and default to `$python -m ipyparallel.cluster` for ipcluster_cmd in SSHProxy
- add SSHProxy to test_ssh