### PR TITLE
fix setting default parent

### DIFF
--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -264,6 +264,12 @@ class Cluster(AsyncFirst, LoggingConfigurable):
     _controller = Any()
     _engine_sets = Dict()
 
+    def __init__(self, **kwargs):
+        """Construct a Cluster"""
+        if 'parent' not in kwargs and 'config' not in kwargs:
+            kwargs['parent'] = self._default_parent()
+        super().__init__(**kwargs)
+
     def __del__(self):
         if not self.shutdown_atexit:
             return


### PR DESCRIPTION
must be set in __init__ prior to calling super

otherwise parent.config won't be loaded