### PR TITLE
name threads/processes in controller

### DIFF
--- a/ipyparallel/controller/broadcast_scheduler.py
+++ b/ipyparallel/controller/broadcast_scheduler.py
@@ -21,10 +21,6 @@ class BroadcastScheduler(Scheduler):
     outgoing_streams = List()
 
     def start(self):
-        self.log.info(
-            'Broadcast Scheduler started with pid=%s',
-            os.getpid(),
-        )
         self.client_stream.on_recv(self.dispatch_submission, copy=False)
         if self.is_leaf:
             super().start()


### PR DESCRIPTION
For better error reporting / debugging

Instead of `Process-1`, `Process-2`, processes all have names (`ControlScheduler`, etc.)