### PR TITLE
Improvements for handling engine death

### DIFF
--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -913,14 +913,17 @@ class Hub(LoggingConfigurable):
             eid = msg['content']['id']
         except:
             self.log.error(
-                "registration::bad engine id for unregistration: %r",
-                ident,
-                exc_info=True,
+                f"registration::bad request for engine for unregistration: {msg['content']}",
             )
             return
-        self.log.info("registration::unregister_engine(%r)", eid)
-
+        if eid not in self.engines:
+            self.log.info(
+                f"registration::unregister_engine({eid}) already unregistered"
+            )
+            return
+        self.log.info(f"registration::unregister_engine({eid})")
         ec = self.engines[eid]
+
         content = dict(id=eid, uuid=ec.uuid)
 
         # stop the heartbeats

--- a/ipyparallel/engine/app.py
+++ b/ipyparallel/engine/app.py
@@ -519,7 +519,7 @@ class IPEngine(BaseParallelApplication):
             # control stream:
             control_url = url('control')
             if self.enable_nanny:
-                nanny_url = self.start_nanny(
+                nanny_url, self.nanny_pipe = self.start_nanny(
                     control_url=control_url,
                 )
                 control_url = nanny_url

--- a/ipyparallel/tests/clienttest.py
+++ b/ipyparallel/tests/clienttest.py
@@ -32,6 +32,12 @@ def crash():
     os._exit(1)
 
 
+def conditional_crash(condition):
+    """Ungracefully exit the process"""
+    if condition:
+        crash()
+
+
 def wait(n):
     """sleep for a time"""
     import time


### PR DESCRIPTION
- fix notification in BroadcastView, which didn't track outstanding msgs for engines (test coverage added as well)
- avoid logging KeyError when an engine  is unregistered twice (can be caused by death-notification from both nanny and heartbeat
- avoid launching nanny with fork (doesn't seem to have any effect, but may cause issues in mpi)
- use pipe to notice zombie processes (e.g. MPICH, which doesn't reliably reap workers with children)