### PR TITLE
avoid races in progress bars

### DIFF
--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -620,14 +620,13 @@ class AsyncResult(Future):
         tic = time.perf_counter()
         progress_bar = progress(widget=widget, total=N, unit='tasks', desc=self._fname)
 
-        n_prev = 0
         while not self.ready() and (
             timeout is None or time.perf_counter() - tic <= timeout
         ):
             self.wait(interval)
-            progress_bar.update(self.progress - n_prev)
-            n_prev = self.progress
+            progress_bar.update(self.progress - progress_bar.n)
 
+        progress_bar.update(self.progress - progress_bar.n)
         progress_bar.close()
 
     def _republish_displaypub(self, content, eid):

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1381,7 +1381,10 @@ class Client(HasTraits):
 
         if interactive:
             progress_bar = util.progress(
-                widget=widget, initial=len(self.ids), total=n, unit='engine'
+                widget=widget,
+                initial=len(self.ids),
+                total=n,
+                unit='engine',
             )
 
         future = Future()
@@ -1389,9 +1392,10 @@ class Client(HasTraits):
         def notify(_):
             if future.done():
                 return
+            current_n = len(self.ids)
             if interactive:
-                progress_bar.update(len(self.ids) - progress_bar.n)
-            if len(self.ids) >= n:
+                progress_bar.update(current_n - progress_bar.n)
+            if current_n >= n:
                 # ensure we refresh when we finish
                 if interactive:
                     progress_bar.close()
@@ -1405,12 +1409,13 @@ class Client(HasTraits):
             if future.done():
                 return
 
-            if len(self.ids) >= n:
+            current_n = len(self.ids)
+            if current_n >= n:
                 future.set_result(None)
             else:
                 future.set_exception(
                     TimeoutError(
-                        f"{n} engines not ready in {timeout} seconds. Currently ready: {len(self.ids)}"
+                        f"{n} engines not ready in {timeout} seconds. Currently ready: {current_n}"
                     )
                 )
 

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -22,7 +22,6 @@ from signal import signal
 from signal import SIGTERM
 from types import FunctionType
 
-import tqdm
 import traitlets
 import zmq
 from dateutil.parser import parse as dateutil_parse
@@ -657,8 +656,12 @@ def progress(*args, widget=None, **kwargs):
         else:
             widget = False
     if widget:
-        f = tqdm.tqdm_notebook
+        import tqdm.notebook
+
+        f = tqdm.notebook.tqdm_notebook
     else:
+        import tqdm
+
         kwargs.setdefault("file", sys.stdout)
         f = tqdm.tqdm
     return f(*args, **kwargs)


### PR DESCRIPTION
computing `len(client.ids)` or `AsyncResult.progress` can change on each call due to updates from the io thread,
so avoid accessing more than once within a single computation.

closes #526 