### PR TITLE
Improve launcher cleanup

### DIFF
--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -16,6 +16,7 @@ import socket
 import string
 import sys
 import time
+import traceback
 from functools import partial
 from multiprocessing import cpu_count
 from weakref import WeakSet
@@ -56,7 +57,11 @@ def _atexit_cleanup_clusters(*args):
             continue
         if cluster.controller or cluster.engines:
             print(f"Stopping cluster {cluster}", file=sys.stderr)
-            cluster.stop_cluster_sync()
+            try:
+                cluster.stop_cluster_sync()
+            except Exception:
+                print(f"Error stopping cluster {cluster}", file=sys.stderr)
+                traceback.print_exception(*sys.exc_info())
 
 
 _atexit_cleanup_clusters.registered = False


### PR DESCRIPTION
- Handle errors when attempting to shutdown processes during process teardown (pool.submit cannot be called during atexit)
- Add Launcher.NotRunning exception that indicates a Launcher process has been cleaned up (as opposed to unhandled errors, which still propagate)

The result should be better listing / cleanup of clusters no matter how/when the stop.

Other Launchers, such as ssh, may need special handling to distinguish a real failure from a networking issue.