### PR TITLE
Rework port configuration

### DIFF
--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -486,10 +486,10 @@ class Client(HasTraits):
             'iopub',
             'notification',
             'registration',
+            'broadcast',
         ):
             cfg[key] = cfg['interface'] + ':%i' % cfg[key]
 
-        cfg['broadcast'] = cfg['interface'] + ':%i' % cfg['broadcast'][0]
         url = cfg['registration']
 
         if location is not None and addr == localhost():

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -871,10 +871,10 @@ class DirectView(View):
 class BroadcastView(DirectView):
     is_coalescing = Bool(False)
 
-    def _init_metadata(self, s_idents):
+    def _init_metadata(self, target_tuples):
         """initialize request metadata"""
         return dict(
-            targets=s_idents,
+            targets=target_tuples,
             is_broadcast=True,
             is_coalescing=self.is_coalescing,
         )
@@ -931,8 +931,9 @@ class BroadcastView(DirectView):
         pkwargs = {k: PrePickled(v) for k, v in kwargs.items()}
 
         s_idents = [ident.decode("utf8") for ident in idents]
+        target_tuples = list(zip(s_idents, _targets))
 
-        metadata = self._init_metadata(s_idents)
+        metadata = self._init_metadata(target_tuples)
 
         ar = None
 
@@ -979,8 +980,9 @@ class BroadcastView(DirectView):
 
         _idents, _targets = self.client._build_targets(targets)
         s_idents = [ident.decode("utf8") for ident in _idents]
+        target_tuples = list(zip(s_idents, _targets))
 
-        metadata = self._init_metadata(s_idents)
+        metadata = self._init_metadata(target_tuples)
 
         ar = None
 

--- a/ipyparallel/controller/broadcast_scheduler.py
+++ b/ipyparallel/controller/broadcast_scheduler.py
@@ -3,6 +3,7 @@ import logging
 import zmq
 from traitlets import Bool
 from traitlets import Bytes
+from traitlets import Integer
 from traitlets import List
 
 from ipyparallel import util
@@ -17,6 +18,8 @@ class BroadcastScheduler(Scheduler):
     is_leaf = Bool(False)
     connected_sub_scheduler_ids = List(Bytes())
     outgoing_streams = List()
+    depth = Integer()
+    max_depth = Integer()
 
     def start(self):
         self.client_stream.on_recv(self.dispatch_submission, copy=False)
@@ -46,10 +49,21 @@ class BroadcastScheduler(Scheduler):
                 scheduler_id: None for scheduler_id in self.connected_sub_scheduler_ids
             }
 
+        trunc = 2 ** self.max_depth
+        fmt = f"0{self.max_depth + 1}b"
+
+        # assign targets to sub-schedulers based on binary path
+        # compute binary '010110' representation of the engine id
+        targets_by_scheduler = [
+            [] for i in range(len(self.connected_sub_scheduler_ids))
+        ]
+        for target_tuple in targets:
+            path = format(target_tuple[1] % trunc, fmt)
+            next_idx = int(path[self.depth + 1])  # 0 or 1
+            targets_by_scheduler[next_idx].append(target_tuple)
+
         for i, scheduler_id in enumerate(self.connected_sub_scheduler_ids):
-            slice_start = i * len(targets) // len(self.connected_sub_scheduler_ids)
-            slice_end = (i + 1) * len(targets) // len(self.connected_sub_scheduler_ids)
-            targets_for_scheduler = targets[slice_start:slice_end]
+            targets_for_scheduler = targets_by_scheduler[i]
             if not targets_for_scheduler and is_coalescing:
                 del self.accumulated_replies[original_msg_id][scheduler_id]
             msg['metadata']['targets'] = targets_for_scheduler
@@ -106,7 +120,10 @@ class BroadcastScheduler(Scheduler):
 
         original_msg_id = metadata['original_msg_id']
         if self.is_leaf:
-            self.send_to_targets(msg, original_msg_id, targets, idents, is_coalescing)
+            target_idents = [t[0] for t in targets]
+            self.send_to_targets(
+                msg, original_msg_id, target_idents, idents, is_coalescing
+            )
         else:
             self.send_to_sub_schedulers(
                 msg, original_msg_id, targets, idents, is_coalescing
@@ -150,12 +167,13 @@ def launch_broadcast_scheduler(
     in_thread=False,
     outgoing_ids=None,
     depth=0,
+    max_depth=0,
 ):
     config, ctx, loop, mons, nots, querys, log = get_common_scheduler_streams(
         mon_addr, not_addr, reg_addr, config, 'scheduler', log_url, loglevel, in_thread
     )
 
-    is_root = identity == 0
+    is_root = depth == 0
     sub_scheduler_id = get_id_with_prefix(identity)
 
     incoming_stream = ZMQStream(ctx.socket(zmq.ROUTER), loop)
@@ -183,6 +201,8 @@ def launch_broadcast_scheduler(
         loop=loop,
         log=log,
         config=config,
+        depth=depth,
+        max_depth=max_depth,
     )
     if is_leaf:
         scheduler_args.update(engine_stream=outgoing_streams[0], is_leaf=True)

--- a/ipyparallel/engine/app.py
+++ b/ipyparallel/engine/app.py
@@ -502,9 +502,16 @@ class IPEngine(BaseParallelApplication):
             self.log.name += f".{self.id}"
 
             # create Shell Connections (MUX, Task, etc.):
-            shell_addrs = [url('mux'), url('task')] + urls('broadcast')
 
-            self.log.info(f'ENGINE: shell_addrs: {shell_addrs}')
+            # select which broadcast endpoint to connect to
+            # use rank % len(broadcast_leaves)
+            broadcast_urls = urls('broadcast')
+            broadcast_leaves = len(broadcast_urls)
+            broadcast_index = self.id % len(broadcast_urls)
+            broadcast_url = broadcast_urls[broadcast_index]
+
+            shell_addrs = [url('mux'), url('task'), broadcast_url]
+            self.log.info(f'Shell_addrs: {shell_addrs}')
 
             # Use only one shell stream for mux and tasks
             stream = zmqstream.ZMQStream(ctx.socket(zmq.ROUTER), loop)


### PR DESCRIPTION
- only put single broadcast port in client connection file, since there is only one port for clients
- add IPController.ports configuration 


so you can do

```
ipcontroller --ports 10101-10120
```

to assign all ports used by the controller. The controller will consume these ports in a deterministic order.

A controller needs at least 16 ports (18 by default) for all the schedulers, etc.

closes #355 (doesn't implement specifying a range for random ports, but instead makes it feasible to always specify the full port range for each controller))

closes #498 by only connecting engines to one broadcast leaf at a time

path is calculated using binary encoding of the integer rank, so engine 0 gets messages through scheduler path '0000', engine 3 through '0011' etc.