### PR TITLE
Run heart monitor in its own process

### DIFF
--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -797,7 +797,7 @@ class MPILauncher(LocalProcessLauncher):
             if deprecated:
                 newname = oldname.replace('MPIExec', 'MPI')
                 config[newname].update(deprecated)
-                self.log.warn(
+                self.log.warning(
                     "WARNING: %s name has been deprecated, use %s", oldname, newname
                 )
 
@@ -913,7 +913,7 @@ class DeprecatedMPILauncher:
     def warn(self):
         oldname = self.__class__.__name__
         newname = oldname.replace('MPIExec', 'MPI')
-        self.log.warn("WARNING: %s name is deprecated, use %s", oldname, newname)
+        self.log.warning("WARNING: %s name is deprecated, use %s", oldname, newname)
 
 
 class MPIExecLauncher(MPILauncher, DeprecatedMPILauncher):

--- a/ipyparallel/controller/heartmonitor.py
+++ b/ipyparallel/controller/heartmonitor.py
@@ -11,8 +11,10 @@ import time
 import uuid
 
 import zmq
+from jupyter_client.session import Session
 from tornado import ioloop
 from traitlets import Bool
+from traitlets import default
 from traitlets import Dict
 from traitlets import Float
 from traitlets import Instance
@@ -21,8 +23,10 @@ from traitlets import Set
 from traitlets.config.configurable import LoggingConfigurable
 from zmq.devices import ThreadDevice
 from zmq.devices import ThreadMonitoredQueue
+from zmq.eventloop.zmqstream import ZMQStream
 
 from ipyparallel.util import log_errors
+from ipyparallel.util import set_hwm
 
 
 class Heart:
@@ -76,9 +80,10 @@ class Heart:
 
 class HeartMonitor(LoggingConfigurable):
     """A basic HeartMonitor class
-    pingstream: a PUB stream
-    pongstream: an ROUTER stream
-    period: the period of the heartbeat in milliseconds"""
+    ping_stream: a PUB stream
+    pong_stream: an ROUTER stream
+    period: the period of the heartbeat in milliseconds
+    """
 
     debug = Bool(
         False,
@@ -100,10 +105,18 @@ class HeartMonitor(LoggingConfigurable):
         help='Allowed consecutive missed pings from controller Hub to engine before unregistering.',
     )
 
-    pingstream = Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
-    pongstream = Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
-    loop = Instance('tornado.ioloop.IOLoop')
+    ping_stream = Instance(ZMQStream)
+    pong_stream = Instance(ZMQStream)
+    monitor_stream = Instance(ZMQStream)
+    session = Instance(Session)
 
+    @default("session")
+    def _default_session(self):
+        return Session(parent=self)
+
+    loop = Instance(ioloop.IOLoop)
+
+    @default("loop")
     def _loop_default(self):
         return ioloop.IOLoop.current()
 
@@ -112,57 +125,44 @@ class HeartMonitor(LoggingConfigurable):
     responses = Set()
     on_probation = Dict()
     last_ping = Float(0)
-    _new_handlers = Set()
-    _failure_handlers = Set()
     lifetime = Float(0)
     tic = Float(0)
 
-    def __init__(self, **kwargs):
-        super(HeartMonitor, self).__init__(**kwargs)
-
-        self.pongstream.on_recv(self.handle_pong)
-
     def start(self):
-        self.tic = time.time()
+        self.log.debug("heartbeat::waiting for subscription")
+        msg = self.monitor_stream.socket.recv_multipart()
+        self.log.debug("heartbeat::subscription started")
+        self.pong_stream.on_recv(self.handle_pong)
+        self.tic = time.monotonic()
         self.caller = ioloop.PeriodicCallback(self.beat, self.period)
         self.caller.start()
 
-    def add_new_heart_handler(self, handler):
-        """add a new handler for new hearts"""
-        self.log.debug("heartbeat::new_heart_handler: %s", handler)
-        self._new_handlers.add(handler)
-
-    def add_heart_failure_handler(self, handler):
-        """add a new handler for heart failure"""
-        self.log.debug("heartbeat::new heart failure handler: %s", handler)
-        self._failure_handlers.add(handler)
-
     def beat(self):
-        self.pongstream.flush()
+        self.pong_stream.flush()
         self.last_ping = self.lifetime
 
-        toc = time.time()
+        toc = time.monotonic()
         self.lifetime += toc - self.tic
         self.tic = toc
         if self.debug:
             self.log.debug("heartbeat::sending %s", self.lifetime)
-        goodhearts = self.hearts.intersection(self.responses)
-        missed_beats = self.hearts.difference(goodhearts)
-        newhearts = self.responses.difference(goodhearts)
-        for heart in newhearts:
-            self.handle_new_heart(heart)
-        heartfailures, on_probation = self._check_missed(
+        good_hearts = self.hearts.intersection(self.responses)
+        missed_beats = self.hearts.difference(good_hearts)
+        new_hearts = self.responses.difference(good_hearts)
+        if new_hearts:
+            self.handle_new_hearts(new_hearts)
+        heart_failures, on_probation = self._check_missed(
             missed_beats, self.on_probation, self.hearts
         )
-        for failure in heartfailures:
-            self.handle_heart_failure(failure)
+        if heart_failures:
+            self.handle_heart_failure(heart_failures)
         self.on_probation = on_probation
         self.responses = set()
         # print self.on_probation, self.hearts
         # self.log.debug("heartbeat::beat %.3f, %i beating hearts", self.lifetime, len(self.hearts))
-        self.pingstream.send(str(self.lifetime).encode('ascii'))
+        self.ping_stream.send(str(self.lifetime).encode('ascii'))
         # flush stream to force immediate socket send
-        self.pingstream.flush()
+        self.ping_stream.flush()
 
     def _check_missed(self, missed_beats, on_probation, hearts):
         """Update heartbeats on probation, identifying any that have too many misses."""
@@ -177,52 +177,94 @@ class HeartMonitor(LoggingConfigurable):
                 new_probation[cur_heart] = miss_count
         return failures, new_probation
 
-    def handle_new_heart(self, heart):
-        if self._new_handlers:
-            for handler in self._new_handlers:
-                handler(heart)
-        else:
-            self.log.info("heartbeat::yay, got new heart %s!", heart)
-        self.hearts.add(heart)
+    def handle_new_hearts(self, hearts):
+        for heart in hearts:
+            self.hearts.add(heart)
+        self.session.send(
+            self.monitor_stream,
+            "new_heart",
+            content={
+                "hearts": [h.decode("utf8", "replace") for h in hearts],
+            },
+            ident=[b"heartmonitor", b""],
+        )
 
-    def handle_heart_failure(self, heart):
-        if self._failure_handlers:
-            for handler in self._failure_handlers:
-                try:
-                    handler(heart)
-                except Exception as e:
-                    self.log.error("heartbeat::Bad Handler! %s", handler, exc_info=True)
-                    pass
-        else:
-            self.log.info("heartbeat::Heart %s failed :(", heart)
-        try:
-            self.hearts.remove(heart)
-        except KeyError:
-            self.log.info("heartbeat:: %s has already been removed." % heart)
+    def handle_heart_failure(self, hearts):
+        self.session.send(
+            self.monitor_stream,
+            "stopped_heart",
+            content={
+                "hearts": [h.decode("utf8", "replace") for h in hearts],
+            },
+            ident=[b"heartmonitor", b""],
+        )
+        for heart in hearts:
+            try:
+                self.hearts.remove(heart)
+            except KeyError:
+                self.log.info("heartbeat:: %s has already been removed.", heart)
 
     @log_errors
     def handle_pong(self, msg):
-        "a heart just beat"
+        """a heart just beat"""
         current = str(self.lifetime).encode('ascii')
         last = str(self.last_ping).encode('ascii')
         if msg[1] == current:
-            delta = time.time() - self.tic
+            delta = time.monotonic() - self.tic
             if self.debug:
                 self.log.debug(
                     "heartbeat::heart %r took %.2f ms to respond", msg[0], 1000 * delta
                 )
             self.responses.add(msg[0])
         elif msg[1] == last:
-            delta = time.time() - self.tic + (self.lifetime - self.last_ping)
-            self.log.warn(
+            delta = time.monotonic() - self.tic + (self.lifetime - self.last_ping)
+            self.log.warning(
                 "heartbeat::heart %r missed a beat, and took %.2f ms to respond",
                 msg[0],
                 1000 * delta,
             )
             self.responses.add(msg[0])
         else:
-            self.log.warn(
+            self.log.warning(
                 "heartbeat::got bad heartbeat (possibly old?): %s (current=%.3f)",
                 msg[1],
                 self.lifetime,
             )
+
+
+def start_heartmonitor(ping_url, pong_url, monitor_url, **kwargs):
+    """Start a heart monitor.
+
+    For use in a background process,
+    via Process(target=start_heartmonitor)
+    """
+    loop = ioloop.IOLoop()
+    loop.make_current()
+    ctx = zmq.Context()
+
+    ping_socket = ctx.socket(zmq.PUB)
+    ping_socket.bind(ping_url)
+    ping_stream = ZMQStream(ping_socket)
+
+    pong_socket = ctx.socket(zmq.ROUTER)
+    set_hwm(pong_socket, 0)
+    pong_socket.bind(pong_url)
+    pong_stream = ZMQStream(pong_socket)
+
+    monitor_socket = ctx.socket(zmq.XPUB)
+    monitor_socket.connect(monitor_url)
+    monitor_stream = ZMQStream(monitor_socket)
+
+    heart_monitor = HeartMonitor(
+        ping_stream=ping_stream,
+        pong_stream=pong_stream,
+        monitor_stream=monitor_stream,
+        **kwargs,
+    )
+    heart_monitor.start()
+
+    try:
+        loop.start()
+    finally:
+        loop.close(all_fds=True)
+    ctx.destroy()

--- a/ipyparallel/controller/heartmonitor.py
+++ b/ipyparallel/controller/heartmonitor.py
@@ -180,6 +180,7 @@ class HeartMonitor(LoggingConfigurable):
     def handle_new_hearts(self, hearts):
         for heart in hearts:
             self.hearts.add(heart)
+        self.log.debug(f"Notifying hub of {len(hearts)} new hearts")
         self.session.send(
             self.monitor_stream,
             "new_heart",
@@ -190,6 +191,7 @@ class HeartMonitor(LoggingConfigurable):
         )
 
     def handle_heart_failure(self, hearts):
+        self.log.debug(f"Notifying hub of {len(hearts)} stopped hearts")
         self.session.send(
             self.monitor_stream,
             "stopped_heart",

--- a/ipyparallel/controller/hub.py
+++ b/ipyparallel/controller/hub.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import time
+from collections import deque
 from datetime import datetime
 
 from jupyter_client.jsonutil import parse_date
@@ -19,6 +20,7 @@ from jupyter_client.session import Session
 from tornado import ioloop
 from traitlets import Any
 from traitlets import Bytes
+from traitlets import default
 from traitlets import Dict
 from traitlets import HasTraits
 from traitlets import Instance
@@ -152,6 +154,7 @@ class Hub(LoggingConfigurable):
     by_ident = Dict()  # map bytes identities : int engine id
     engines = Dict()  # map int engine id : EngineConnector
     hearts = Dict()  # map bytes identities : int engine id, only for active heartbeats
+    heartmonitor_period = Integer()
     pending = Set()
     queues = Dict()  # pending msg_ids keyed by engine_id
     tasks = Dict()  # pending msg_ids submitted as tasks, keyed by client_id
@@ -163,8 +166,18 @@ class Hub(LoggingConfigurable):
     _idcounter = Integer(0)
     distributed_scheduler = Any()
 
+    expect_stopped_hearts = Instance(deque)
+
+    @default("expect_stopped_hearts")
+    def _default_expect_stopped_hearts(self):
+        # remember the last this-many hearts
+        # silences warnings about ignoring stopped hearts for unregistered engines
+        # harmless, but noisy if they happen on every unregistration
+        return deque(maxlen=1024)
+
     loop = Instance(ioloop.IOLoop)
 
+    @default("loop")
     def _default_loop(self):
         return ioloop.IOLoop.current()
 
@@ -194,14 +207,11 @@ class Hub(LoggingConfigurable):
         client_info: zmq address/protocol dict for client connections
         """
 
-        super(Hub, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # register our callbacks
         self.query.on_recv(self.dispatch_query)
         self.monitor.on_recv(self.dispatch_monitor_traffic)
-
-        self.heartmonitor.add_heart_failure_handler(self.handle_heart_failure)
-        self.heartmonitor.add_new_heart_handler(self.handle_new_heart)
 
         self.monitor_handlers = {
             b'in': self.save_queue_request,
@@ -214,6 +224,7 @@ class Hub(LoggingConfigurable):
             b'incontrol': _passer,
             b'outcontrol': _passer,
             b'iopub': self.monitor_iopub_message,
+            b'heartmonitor': self.heartmonitor_message,
         }
 
         self.query_handlers = {
@@ -366,25 +377,49 @@ class Hub(LoggingConfigurable):
 
     # ----------------------- Heartbeat --------------------------------------
 
+    @util.log_errors
+    def heartmonitor_message(self, topics, msg):
+        """Handle a message from the heart monitor"""
+        try:
+            msg = self.session.deserialize(msg)
+        except Exception:
+            self.log.error(
+                "heartmonitor::invalid message %r",
+                msg,
+                exc_info=True,
+            )
+            return
+        msg_type = msg['header']['msg_type']
+        if msg_type == 'new_heart':
+            hearts = msg['content']['hearts']
+            self.log.info(f"Registering {len(hearts)} new hearts")
+            for heart in hearts:
+                self.handle_new_heart(heart.encode("utf8"))
+        elif msg_type == 'stopped_heart':
+            hearts = msg['content']['hearts']
+            self.log.warning(f"{len(hearts)} hearts stopped")
+            for heart in hearts:
+                self.handle_stopped_heart(heart.encode("utf8"))
+
     def handle_new_heart(self, heart):
-        """handler to attach to heartbeater.
-        Called when a new heart starts to beat.
-        Triggers completion of registration."""
+        """Handle a new heart that just started beating"""
         self.log.debug("heartbeat::handle_new_heart(%r)", heart)
         if heart not in self.incoming_registrations:
             self.log.info("heartbeat::ignoring new heart: %r", heart)
         else:
             self.finish_registration(heart)
 
-    def handle_heart_failure(self, heart):
-        """handler to attach to heartbeater.
-        called when a previously registered heart fails to respond to beat request.
-        triggers unregistration"""
-        self.log.debug("heartbeat::handle_heart_failure(%r)", heart)
+    def handle_stopped_heart(self, heart):
+        """Handle notification that heart has stopped"""
+        self.log.debug("heartbeat::handle_stopped_heart(%r)", heart)
         eid = self.hearts.get(heart, None)
         if eid is None:
-            self.log.info(
-                "heartbeat::ignoring heart failure %r (not an engine or already dead)",
+            if heart in self.expect_stopped_hearts:
+                log = self.log.debug
+            else:
+                log = self.log.info
+            log(
+                "heartbeat::ignoring heart failure %r (probably unregistered already)",
                 heart,
             )
         else:
@@ -431,7 +466,7 @@ class Hub(LoggingConfigurable):
             for key, evalue in existing.items():
                 rvalue = record.get(key, None)
                 if evalue and rvalue and evalue != rvalue:
-                    self.log.warn(
+                    self.log.warning(
                         "conflicting initial state for record: %r:%r <%r> %r",
                         msg_id,
                         rvalue,
@@ -489,7 +524,7 @@ class Hub(LoggingConfigurable):
         elif msg_id not in self.all_completed:
             # it could be a result from a dead engine that died before delivering the
             # result
-            self.log.warn("queue:: unknown msg finished %r", msg_id)
+            self.log.warning("queue:: unknown msg finished %r", msg_id)
             return
         # update record anyway, because the unregistration could have been premature
         rheader = msg['header']
@@ -549,7 +584,7 @@ class Hub(LoggingConfigurable):
         # save the result of a completed broadcast
         parent = msg['parent_header']
         if not parent:
-            self.log.warn(f'Broadcast message {msg} had no parent')
+            self.log.warning(f'Broadcast message {msg} had no parent')
             return
         msg_id = parent['msg_id']
         header = msg['header']
@@ -629,7 +664,7 @@ class Hub(LoggingConfigurable):
                     continue
                 rvalue = record.get(key, None)
                 if evalue and rvalue and evalue != rvalue:
-                    self.log.warn(
+                    self.log.warning(
                         "conflicting initial state for record: %r:%r <%r> %r",
                         msg_id,
                         rvalue,
@@ -667,7 +702,7 @@ class Hub(LoggingConfigurable):
         parent = msg['parent_header']
         if not parent:
             # print msg
-            self.log.warn("Task %r had no parent!", msg)
+            self.log.warning("Task %r had no parent!", msg)
             return
         msg_id = parent['msg_id']
         if msg_id in self.unassigned:
@@ -795,7 +830,7 @@ class Hub(LoggingConfigurable):
         elif msg_type == 'data_pub':
             self.log.info("ignored data_pub message for %s" % msg_id)
         else:
-            self.log.warn("unhandled iopub msg_type: %r", msg_type)
+            self.log.warning("unhandled iopub msg_type: %r", msg_type)
 
         if not d:
             return
@@ -847,7 +882,7 @@ class Hub(LoggingConfigurable):
         content = dict(
             id=eid,
             status='ok',
-            hb_period=self.heartmonitor.period,
+            hb_period=self.heartmonitor_period,
             connection_info=self.engine_info,
         )
         # check if requesting available IDs:
@@ -881,21 +916,13 @@ class Hub(LoggingConfigurable):
         heart = uuid.encode("utf8")
 
         if content['status'] == 'ok':
-            if heart in self.heartmonitor.hearts:
-                # already beating
-                self.incoming_registrations[heart] = EngineConnector(
-                    id=eid, uuid=uuid, ident=heart
-                )
-                self.finish_registration(heart)
-            else:
-                purge = lambda: self._purge_stalled_registration(heart)
-                t = self.loop.add_timeout(
-                    self.loop.time() + self.registration_timeout,
-                    purge,
-                )
-                self.incoming_registrations[heart] = EngineConnector(
-                    id=eid, uuid=uuid, ident=heart, stallback=t
-                )
+            t = self.loop.add_timeout(
+                self.loop.time() + self.registration_timeout,
+                lambda: self._purge_stalled_registration(heart),
+            )
+            self.incoming_registrations[heart] = EngineConnector(
+                id=eid, uuid=uuid, ident=heart, stallback=t
+            )
         else:
             self.log.error(
                 "registration::registration %i failed: %r", eid, content['evalue']
@@ -924,8 +951,7 @@ class Hub(LoggingConfigurable):
 
         # stop the heartbeats
         self.hearts.pop(ec.ident, None)
-        self.heartmonitor.responses.discard(ec.ident)
-        self.heartmonitor.hearts.discard(ec.ident)
+        self.expect_stopped_hearts.append(ec.ident)
 
         self.loop.add_timeout(
             self.loop.time() + self.registration_timeout,
@@ -1060,9 +1086,6 @@ class Hub(LoggingConfigurable):
         self.notifier = None
         for eid, uuid in state['engines'].items():
             heart = uuid.encode('ascii')
-            # start with this heart as current and beating:
-            self.heartmonitor.responses.add(heart)
-            self.heartmonitor.hearts.add(heart)
 
             self.incoming_registrations[heart] = EngineConnector(
                 id=int(eid), uuid=uuid, ident=heart

--- a/ipyparallel/controller/sqlitedb.py
+++ b/ipyparallel/controller/sqlitedb.py
@@ -236,11 +236,11 @@ class SQLiteDB(BaseDB):
             types[line[1]] = line[2]
         if self._keys != keys:
             # key mismatch
-            self.log.warn('keys mismatch')
+            self.log.warning('keys mismatch')
             return False
         for key in self._keys:
             if types[key] != self._types[key]:
-                self.log.warn(
+                self.log.warning(
                     'type mismatch: %s: %s != %s' % (key, types[key], self._types[key])
                 )
                 return False
@@ -269,7 +269,7 @@ class SQLiteDB(BaseDB):
         while not self._check_table():
             i += 1
             self.table = first_table + '_%i' % i
-            self.log.warn(
+            self.log.warning(
                 "Table %s exists and doesn't match db format, trying %s"
                 % (previous_table, self.table)
             )

--- a/ipyparallel/controller/task_scheduler.py
+++ b/ipyparallel/controller/task_scheduler.py
@@ -227,12 +227,12 @@ class TaskScheduler(Scheduler):
         try:
             idents, msg = self.session.feed_identities(msg)
         except ValueError:
-            self.log.warn("task::Invalid Message: %r", msg)
+            self.log.warning("task::Invalid Message: %r", msg)
             return
         try:
             msg = self.session.deserialize(msg)
         except ValueError:
-            self.log.warn("task::Unauthorized message from: %r" % idents)
+            self.log.warning("task::Unauthorized message from: %r" % idents)
             return
 
         content = msg['content']
@@ -245,12 +245,12 @@ class TaskScheduler(Scheduler):
         try:
             idents, msg = self.session.feed_identities(msg)
         except ValueError:
-            self.log.warn("task::Invalid Message: %r", msg)
+            self.log.warning("task::Invalid Message: %r", msg)
             return
         try:
             msg = self.session.deserialize(msg)
         except ValueError:
-            self.log.warn("task::Unauthorized message from: %r" % idents)
+            self.log.warning("task::Unauthorized message from: %r" % idents)
             return
 
         msg_type = msg['header']['msg_type']
@@ -451,7 +451,7 @@ class TaskScheduler(Scheduler):
             return
         now = time.time()
         if job.timeout >= (now + 1):
-            self.log.warn(
+            self.log.warning(
                 "task %s timeout fired prematurely: %s > %s",
                 job.msg_id,
                 job.timeout,

--- a/ipyparallel/engine/app.py
+++ b/ipyparallel/engine/app.py
@@ -695,7 +695,7 @@ class IPEngine(BaseParallelApplication):
         self._hb_listener.flush()
         if self._hb_last_monitored > self._hb_last_pinged:
             self._hb_missed_beats += 1
-            self.log.warn(
+            self.log.warning(
                 "No heartbeat in the last %s ms (%s time(s) in a row).",
                 self.hb_check_period,
                 self._hb_missed_beats,
@@ -725,8 +725,8 @@ class IPEngine(BaseParallelApplication):
         self.find_url_file()
 
         if self.wait_for_url_file and not os.path.exists(self.url_file):
-            self.log.warn("url_file %r not found", self.url_file)
-            self.log.warn(
+            self.log.warning("url_file %r not found", self.url_file)
+            self.log.warning(
                 "Waiting up to %.1f seconds for it to arrive.", self.wait_for_url_file
             )
             tic = time.time()

--- a/ipyparallel/engine/app.py
+++ b/ipyparallel/engine/app.py
@@ -227,6 +227,17 @@ class IPEngine(BaseParallelApplication):
         config=True,
         help="""Code to execute in the user namespace when initializing MPI""",
     )
+    mpi_registration_delay = Float(
+        0.02,
+        config=True,
+        help="""Per-engine delay for mpiexec-launched engines
+
+        avoids flooding the controller with registrations,
+        which can stall under heavy load.
+
+        Default: .02 (50 engines/sec, or 3000 engines/minute)
+        """,
+    )
 
     # not configurable:
     user_ns = Dict()
@@ -444,6 +455,16 @@ class IPEngine(BaseParallelApplication):
 
     def register(self):
         """send the registration_request"""
+        if self.use_mpi and self.id and self.id >= 100 and self.mpi_registration_delay:
+            # Some launchres implement delay at the Launcher level,
+            # but mpiexec must implement it int he engine process itself
+            # delay based on our rank
+
+            delay = self.id * self.mpi_registration_delay
+            self.log.info(
+                f"Delaying registration for {self.id} by {int(delay * 1000)}ms"
+            )
+            time.sleep(delay)
 
         self.log.info("Registering with controller at %s" % self.registration_url)
         ctx = self.context
@@ -494,12 +515,15 @@ class IPEngine(BaseParallelApplication):
             return [f'{info["interface"]}:{port}' for port in info[key]]
 
         if content['status'] == 'ok':
-            if self.id is not None and content['id'] != self.id:
-                self.log.warning(
-                    "Did not get the requested id: %i != %i", content['id'], self.id
-                )
+            requested_id = self.id
             self.id = content['id']
-            self.log.name += f".{self.id}"
+            if requested_id is not None and self.id != requested_id:
+                self.log.warning(
+                    f"Did not get the requested id: {self.id} != {requested_id}"
+                )
+                self.log.name = self.log.name.rsplit(".", 1)[0] + f".{self.id}"
+            elif self.id is None:
+                self.log.name += f".{self.id}"
 
             # create Shell Connections (MUX, Task, etc.):
 
@@ -790,6 +814,8 @@ class IPEngine(BaseParallelApplication):
         self.loop.add_callback_from_signal(self.loop.stop)
 
     def start(self):
+        if self.id is not None:
+            self.log.name += f".{self.id}"
         loop = self.loop
 
         def _start():

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,11 @@ from setupbase import wrap_installers, npm_builder, get_data_files
 data_files = get_data_files(data_files_spec)
 
 builder = npm_builder()
-cmdclass = wrap_installers(pre_develop=builder, pre_dist=builder)
+if os.environ.get("IPP_DISABLE_JS") == "1":
+    print("Skipping js installation")
+    cmdclass = {}
+else:
+    cmdclass = wrap_installers(pre_develop=builder, pre_dist=builder)
 
 if "bdist_egg" not in sys.argv:
     cmdclass["bdist_egg"] = bdist_egg_disabled


### PR DESCRIPTION
Engine registration uses the following process:

1. engine sends registration request
2. hub receives registration request, assigns id, and starts a timer (30 seconds by default) for purging stalled registrations
3. engine receives registration reply and finishes setting up sockets
4. heart monitor receives first heartbeat, notifying hub, at which point the engine is considered fully registered and available for scheduling
5. if the first heartbeat is not received by the timeout, registration is cancelled

We do this because engines won't work until all socket connections are fully established, so it's important that they are responding to requests before clients and schedulers are informed that they are available.

The problem: when lots of registrations happen at once (e.g. `mpiexec -n 5000 ipengine`) there's a lot of load on the hub, and many registrations may stall.

Problems with the current design:

1. the timeout *really* wants to measure the time from when the engine handles the reply, but it starts when the hub *builds* the reply. Async things can mean the reply doesn't actually get sent for some time, so the timer could be measuring time when there's no chance of registration actually completing
2. load on the hub can delay heartbeats. The expected registration time is ~1.5 heartbeats (4.5 seconds by default) because it will take at least one full heartbeat interval after the engine finishes connecting its sockets. If the heartbeat is delayed, this, too, will count inappropriately toward a stalled registration.
3. async handlers can mean messages aren't handled promptly, or pending messages have arrived and be waiting to process, and we handle the timeout while the message that would mean the timeout shouldn't be handled is ready and waiting


Solutions in this PR:

1. move heart monitor to its own process, so that hub load cannot interfere with the heartbeat timers
2. notify hub of new/stopped hearts only once per cycle, reducing Hub callbacks per heartbeat during registration from O(N) to 1
3. flush reply before starting purged registration timeout, to make it more likely to be starting closer to the right time
4. flush incoming heartbeat notifications before checking if a registration should be purged
5. implement per-engine startup delay when using MPI inside the engine. This lets us spread out engine start more smoothly, like we do with the local spawner. Default is much faster, though - 50 engines/sec instead of 10 for local.

With this change, I was able to register 5000 engines with fully default configuration. it still takes a while (a couple of minutes, much of which is spent during mpi process warmup before the first registration request arrives). I was using 480 cores on AWS c5.24xlarge nodes. Heartbeat comfortably beats for 5000 engines with no misses, with all engines responding within 300ms each beat.

closes #301
