### PR TITLE
add ipcluster clean and ipcluster stop --all

### DIFF
--- a/ipyparallel/apps/baseapp.py
+++ b/ipyparallel/apps/baseapp.py
@@ -15,7 +15,6 @@ from jupyter_client.session import Session
 from tornado.ioloop import IOLoop
 from traitlets import Bool
 from traitlets import default
-from traitlets import Dict
 from traitlets import Instance
 from traitlets import observe
 from traitlets import Unicode
@@ -126,8 +125,8 @@ class BaseParallelApplication(BaseIPythonApplication):
     def _default_session(self):
         return Session(parent=self)
 
-    aliases = Dict(base_aliases)
-    flags = Dict(base_flags)
+    aliases = base_aliases
+    flags = base_flags
 
     @catch_config_error
     def initialize(self, argv=None):


### PR DESCRIPTION
allows efficient stopping of all clusters and cleaning of all leftover files

To stop everything and remove all leftovers:

```
ipcluster stop --all
ipcluster clean --all
```

I also looked into finding and terminating orphan processes, but this seemed too hazardous, e.g. possibly killing editors looking at ipyparallel-related files.

closes #548