### PR TITLE
Improve some Windows cleanup

### DIFF
--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1027,8 +1027,10 @@ class Client(HasTraits):
         # so that the main thread knows that all our attributes are defined
         if start_evt:
             start_evt.set()
-        self._io_loop.start()
-        self._io_loop.close()
+        try:
+            self._io_loop.start()
+        finally:
+            self._io_loop.close(all_fds=True)
 
     @unpack_message
     def _dispatch_single_reply(self, msg):

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -567,7 +567,7 @@ class LocalProcessLauncher(BaseLauncher):
 
     def signal(self, sig):
         if self.state == 'running':
-            if WINDOWS and sig == SIGKILL:
+            if WINDOWS and sig in {SIGTERM, SIGKILL}:
                 # use Windows tree-kill for better child cleanup
                 cmd = ['taskkill', '/pid', str(self.process.pid), '/t', '/F']
                 check_output(cmd)

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -423,6 +423,7 @@ class LocalProcessLauncher(BaseLauncher):
     stdout = None
     stderr = None
     process = None
+    _wait_thread = None
 
     def find_args(self):
         return self.cmd_and_args
@@ -495,7 +496,8 @@ class LocalProcessLauncher(BaseLauncher):
 
     async def join(self, timeout=None):
         """Wait for the process to exit"""
-        self._wait_thread.join(timeout=timeout)
+        if self._wait_thread is not None:
+            self._wait_thread.join(timeout=timeout)
 
     def _stream_file(self, path):
         """Stream one file"""
@@ -1299,7 +1301,7 @@ class SSHLauncher(LocalProcessLauncher):
                 wait()
             else:
                 await asyncio.wrap_future(future)
-        if getattr(self, '_stop_waiting', None) and getattr(self, "_wait_thread", None):
+        if getattr(self, '_stop_waiting', None) and self._wait_thread:
             self._stop_waiting.set()
             # got here, should be done
             # wait for wait_thread to cleanup


### PR DESCRIPTION
- avoid proactor loop in background io thread (proactor starts a second selector thread for zmq events, which is ~everything in the loop
- use taskkill for term as well as kill, which avoids orphaning scheduler subprocesses

still can't track down a fix for the "Event loop is closed" messages at the end of tests on Windows. These aren't errors, though, they are failures to fully clean up event loops in the right order (failure to close the tornado selector before closing the underlying asyncio loop), so the effect is really just cosmetic