### PR TITLE
reinitialize logging in heartmonitor subprocess

### DIFF
--- a/ipyparallel/controller/app.py
+++ b/ipyparallel/controller/app.py
@@ -791,6 +791,7 @@ class IPController(BaseParallelApplication):
                 pong_url=self.engine_url('hb_pong'),
                 monitor_url=disambiguate_url(self.monitor_url),
                 config=hm_config,
+                log_level=self.log.getEffectiveLevel(),
             ),
             daemon=True,
         )

--- a/ipyparallel/controller/heartmonitor.py
+++ b/ipyparallel/controller/heartmonitor.py
@@ -257,6 +257,12 @@ def start_heartmonitor(ping_url, pong_url, monitor_url, **kwargs):
     monitor_socket.connect(monitor_url)
     monitor_stream = ZMQStream(monitor_socket)
 
+    # reinitialize logging after fork
+    from .app import IPController
+
+    app = IPController(log_level=kwargs.pop("log_level"))
+    kwargs['log'] = app.log
+
     heart_monitor = HeartMonitor(
         ping_stream=ping_stream,
         pong_stream=pong_stream,


### PR DESCRIPTION
avoids losing heartmonitor logs, because logger config gets lost across the fork