### PR TITLE
add packaging to build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
   "jupyterlab>=3.0.0,==3.*",
+  "packaging",
   "setuptools>=40.8.0",
   "wheel",
 ]


### PR DESCRIPTION
with vendored jupyter_packaging (#559), packaging became a direct, rather than transitive, dependency

closes #578 