### PR TITLE
support widgets, progress in %px

### DIFF
--- a/docs/source/examples/Index.ipynb
+++ b/docs/source/examples/Index.ipynb
@@ -31,10 +31,11 @@
     "* [Creating Clusters from Python](Cluster%20API.ipynb)\n",
     "* [Data Publication API](Data%20Publication%20API.ipynb)\n",
     "* [Parallel Magics](Parallel%20Magics.ipynb)\n",
-    "* [Broadcast View](broadcast/Broadcast%20view.ipynb)\n",
     "* [Visualizing AsyncResults](visualizing-tasks.ipynb)\n",
+    "* [Interactive widgets in IPython Parallel](progress.ipynb)\n",
+    "* [Broadcast View](broadcast/Broadcast%20view.ipynb)\n",
     "* [Broadcasting arrays with memmap](broadcast/memmap%20Broadcast.ipynb)\n",
-    "* [Broadcasting arrays with MPI](broadcast/MPI%20Broadcast.ipynb)"
+    "* [Broadcasting arrays with MPI](broadcast/MPI%20Broadcast.ipynb)\n"
    ]
   },
   {

--- a/docs/source/examples/progress.ipynb
+++ b/docs/source/examples/progress.ipynb
@@ -1,0 +1,1631 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e06e6145-5d8a-42f0-a573-883ceefeb456",
+   "metadata": {},
+   "source": [
+    "# Using widgets in IPython Parallel\n",
+    "\n",
+    "IPython Parallel 7.1 introduces basic support for using Jupyter widgets from a notebook to engines.\n",
+    "\n",
+    "This allows things like progress bars for incremental stages,\n",
+    "when IPP's own task-level progress doesn't show you enough information.\n",
+    "\n",
+    "As always, we start by creating and connecting to a cluster:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cc0f626a-4e9e-4cd7-b9d5-37aa72656045",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using existing profile dir: '/Users/minrk/.ipython/profile_default'\n",
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.LocalEngineSetLauncher'>\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dfdbae12208c47ea98ef749d45d64f62",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4 [00:00<?, ?engine/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<DirectView all>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import ipyparallel as ipp\n",
+    "rc = ipp.Cluster(n=4).start_and_connect_sync()\n",
+    "rc.activate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a68b37e-8f8c-4e21-87ff-ff993d74af4d",
+   "metadata": {},
+   "source": [
+    "IPython widgets support updateable readouts of things like progress.\n",
+    "\n",
+    "There are [lots of widgets to choose from][widget list], but for our purposes,\n",
+    "we are going to use `IntProgress`\n",
+    "\n",
+    "[widget list]: https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20List.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a2ee17a5-ba31-4d3e-9a91-cba386b8e2a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "358962d716384d2199b8522907c9033b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntProgress(value=0, description='Step 0', max=10)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "import ipywidgets as W\n",
+    "from IPython.display import display\n",
+    "\n",
+    "progress = W.IntProgress(min=0, max=10, description=\"Step 0\", readout=True)\n",
+    "display(progress)\n",
+    "\n",
+    "for i in range(10):\n",
+    "    progress.value += 1\n",
+    "    progress.description = f\"Step {progress.value}/{progress.max}\"\n",
+    "    time.sleep(0.1)\n",
+    "\n",
+    "progress.bar_style = \"success\" # change color when it's done"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ff1fe0c-adb3-43f7-b89f-f259acc8a72a",
+   "metadata": {},
+   "source": [
+    "IPython Parallel supports progress and interactive waits on AsyncResult objects,\n",
+    "which is great when your tasks are small and you have a lot of them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2d510a7e-69af-4d5f-bdd3-bb35933933bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "05a2877edaee4d75bae10bfa7ada3c32",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<lambda>:   0%|          | 0/1000 [00:00<?, ?tasks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view = rc.load_balanced_view()\n",
+    "view.map_async(lambda x: x * 2, range(1000)).wait_interactive()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1a0ab11-2b31-4122-a4f6-e986d3b9635b",
+   "metadata": {},
+   "source": [
+    "but the unit of progress is each function call.\n",
+    "\n",
+    "If you have only a few large *IPython* tasks,\n",
+    "you only get feedback when the whole task is done on a given engine:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f4af385b-f27b-48a5-83e6-755a973ed83b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc413de6a5964e9bb353b93bd2730f52",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "%px:   0%|          | 0/4 [00:00<?, ?tasks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px --block\n",
+    "import time\n",
+    "\n",
+    "\n",
+    "def do_some_work(t):\n",
+    "    time.sleep(t)\n",
+    "\n",
+    "\n",
+    "do_some_work(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac55bc69-2c58-49eb-ae21-9260ed9485ef",
+   "metadata": {},
+   "source": [
+    "Combining widgets with tasks allows us to show our progress in stages, including showing progress for every engine.\n",
+    "\n",
+    "This way we get to see progress *within* the task, even though IPython Parallel can't tell what's going on within your black-box task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e273d352-3a5b-4c89-83a1-519ccfd62d23",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AsyncResult: scatter>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rc[:].scatter(\"rank\", rc.ids, flatten=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "307a2f86-0948-461e-94f1-748471707feb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[output:3]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e02c6493e62e4ed38d2dfd45b7115667",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntProgress(value=0, description='rank 3: 0', max=10)"
+      ]
+     },
+     "metadata": {
+      "engine": 3
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[output:2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "197376ab6c2247c1af0769eae93220cb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntProgress(value=0, description='rank 2: 0', max=10)"
+      ]
+     },
+     "metadata": {
+      "engine": 2
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[output:0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd5ef98076d94493b57b021455162c56",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntProgress(value=0, description='rank 0: 0', max=10)"
+      ]
+     },
+     "metadata": {
+      "engine": 0
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[output:1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "697cf15dec6447beaa227add1fa986e8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntProgress(value=0, description='rank 1: 0', max=10)"
+      ]
+     },
+     "metadata": {
+      "engine": 1
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8b5ac39bd6114df9b1820ff1402e5a6c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "%px:   0%|          | 0/4 [00:00<?, ?tasks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px --block\n",
+    "import random\n",
+    "\n",
+    "import ipywidgets as W\n",
+    "from IPython.display import display\n",
+    "\n",
+    "n_steps = 10\n",
+    "\n",
+    "progress = W.IntProgress(max=n_steps, description=f\"rank {rank}: 0\")\n",
+    "def _set_color(change):\n",
+    "    if change.new == progress.max:\n",
+    "        progress.bar_style = \"success\"\n",
+    "    else:\n",
+    "        progress.bar_style = \"\"\n",
+    "progress.observe(_set_color, \"value\")\n",
+    "display(progress)\n",
+    "\n",
+    "for i in range(n_steps):\n",
+    "    time.sleep(random.random())\n",
+    "    progress.value += 1\n",
+    "    progress.description = f\"rank {rank}: {progress.value}/{progress.max}\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c110280-58ee-4dc6-8fb9-a51b5aaaae44",
+   "metadata": {},
+   "source": [
+    "Producing progress bars for every engine can get *very* unwieldy if you have more than a few engines.\n",
+    "\n",
+    "Here's an example where only rank 0 reports its progress,\n",
+    "giving a more succinct presentation, assuming rank 0 knows sufficient information about what's going on\n",
+    "(e.g. an MPI-based simulation).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4862476f-c537-42b7-9a0b-fd5553e70e9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[output:0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18aeb0f1db1d47e99b91f8fea71ba7ab",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntProgress(value=0, description='Step 0', max=10)"
+      ]
+     },
+     "metadata": {
+      "engine": 0
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "71644963dbf140ed85f1c7f9f4d4eb85",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "%px:   0%|          | 0/4 [00:00<?, ?tasks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[stdout:2] rank 2: done!\n",
+      "[stdout:1] rank 1: done!\n",
+      "[stdout:0] rank 0: done!\n",
+      "[stdout:3] rank 3: done!\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%px --block\n",
+    "import random\n",
+    "import time\n",
+    "\n",
+    "import ipywidgets as W\n",
+    "from IPython.display import display\n",
+    "\n",
+    "n_steps = 10\n",
+    "\n",
+    "if rank == 0:\n",
+    "    progress = W.IntProgress(max=n_steps, description=\"Step 0\")\n",
+    "    def _set_color(change):\n",
+    "        if change.new == progress.max:\n",
+    "            progress.bar_style = \"success\"\n",
+    "        else:\n",
+    "            progress.bar_style = \"\"\n",
+    "    progress.observe(_set_color, \"value\")\n",
+    "    display(progress)\n",
+    "\n",
+    "for i in range(n_steps):\n",
+    "    time.sleep(random.random())\n",
+    "    if rank == 0:\n",
+    "        progress.value += 1\n",
+    "        progress.description = f\"Step {progress.value}/{progress.max}\"\n",
+    "\n",
+    "print(f\"rank {rank}: done!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5b27f6b-8343-4433-855f-8b0cfcee2150",
+   "metadata": {},
+   "source": [
+    "Widgets also support two-way communication,\n",
+    "using buttons and text areas for input.\n",
+    "These also work in IPython Parallel,\n",
+    "allowing feedback between engines and a notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9382189b-75b5-4ae2-b427-79ae04058958",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[output:0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b40297afd3a3495eb1145dbe9e313c5b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='Rank 0'), Button(description='step', style=ButtonStyle()), IntProgress(value=0, de…"
+      ]
+     },
+     "metadata": {
+      "engine": 0
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[output:1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e30acd834ff43a99619e7fea5d37151",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='Rank 1'), Button(description='step', style=ButtonStyle()), IntProgress(value=0, de…"
+      ]
+     },
+     "metadata": {
+      "engine": 1
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[output:2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "151a34ffb0964032afaca01c181a6b28",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='Rank 2'), Button(description='step', style=ButtonStyle()), IntProgress(value=0, de…"
+      ]
+     },
+     "metadata": {
+      "engine": 2
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[output:3]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a865096cd77c477f8eff5c5aa57eddc6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='Rank 3'), Button(description='step', style=ButtonStyle()), IntProgress(value=0, de…"
+      ]
+     },
+     "metadata": {
+      "engine": 3
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "button = W.Button(description=f\"step\")\n",
+    "progress = W.IntProgress(max=5, description=\"0 / 5\")\n",
+    "count = 0\n",
+    "\n",
+    "\n",
+    "def click_increment(_):\n",
+    "    progress.value += 1\n",
+    "    progress.description = f\"{progress.value} / {progress.max}\"\n",
+    "    if progress.value == progress.max:\n",
+    "        button.disabled = True\n",
+    "        progress.bar_style = \"success\"\n",
+    "\n",
+    "\n",
+    "button.on_click(click_increment)\n",
+    "\n",
+    "display(W.HBox([W.Label(f\"Rank {rank}\"), button, progress]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5871210a-ccc2-4d1f-825c-3aeda52bb77e",
+   "metadata": {},
+   "source": [
+    "This lets you build interactive displays with parallel execution on remote engines.\n",
+    "Useful? Maybe!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "037c70991034492fae395a3cb40eb8d6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cc7a6cea16974b7fa13414459c2900ff",
+       "style": "IPY_MODEL_42f28a75108e45569f0c97ca33c6ed5f",
+       "value": " 4/4 [00:04&lt;00:00,  1.40tasks/s]"
+      }
+     },
+     "05a2877edaee4d75bae10bfa7ada3c32": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a9a9c8b0d3114bd3a496b9c446b5764c",
+        "IPY_MODEL_60607980bd044458a39ca66516869796",
+        "IPY_MODEL_cec37db835eb4d7fb13b0d6ec136d80b"
+       ],
+       "layout": "IPY_MODEL_bfc1523ebad94dd4803a675a8c54b812"
+      }
+     },
+     "082e905b07184530818bc123fb63fc28": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0ca8257a5de4422baf18653d3eaaabb0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0fc04d1691c54db2907ebdd0cfb77b0f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "151a34ffb0964032afaca01c181a6b28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_19fcf49141ac4997926d11b14500d0e8",
+        "IPY_MODEL_7377456ee3674e019f10851fdc0b701b",
+        "IPY_MODEL_a793326d37bc46cc8b8ec74b85bd397e"
+       ],
+       "layout": "IPY_MODEL_a1298fd926004f28a643cf0cbfcc7212"
+      }
+     },
+     "16412eeced9d4f83bb0ad07f1617f226": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "18aeb0f1db1d47e99b91f8fea71ba7ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Step 10/10",
+       "layout": "IPY_MODEL_24424e8b4708429eb92815e5d151e18b",
+       "max": 10,
+       "style": "IPY_MODEL_9eda35d7d1274f39b2cd8b3cc21680c6",
+       "value": 10
+      }
+     },
+     "197376ab6c2247c1af0769eae93220cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "rank 2: 10/10",
+       "layout": "IPY_MODEL_21066341fb894d6a970abf4fb5ec3947",
+       "max": 10,
+       "style": "IPY_MODEL_22a24293c32b4d55ac79e4b37375e9d7",
+       "value": 10
+      }
+     },
+     "19f9886da8f8414aab48f48cedf310d5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "19fcf49141ac4997926d11b14500d0e8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_5befaa01203642e69e5b27eafc333ed7",
+       "style": "IPY_MODEL_d7b6802ae7f7406fa273c7438386bb36",
+       "value": "Rank 2"
+      }
+     },
+     "21066341fb894d6a970abf4fb5ec3947": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "22a24293c32b4d55ac79e4b37375e9d7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "24424e8b4708429eb92815e5d151e18b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "250d9258401b416f9f9cdcdc00536be8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_57f157e4e70e4d6f968529322aceddd7",
+       "max": 4,
+       "style": "IPY_MODEL_57c522897432474696e485348ceedba6",
+       "value": 4
+      }
+     },
+     "31130a5903db4d18be96133232804eb7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "358962d716384d2199b8522907c9033b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Step 10/10",
+       "layout": "IPY_MODEL_b73213ba3e914925aecdf1b851a77787",
+       "max": 10,
+       "style": "IPY_MODEL_57db5fae55984f529f87b20d41374e12",
+       "value": 10
+      }
+     },
+     "36571c1f44e840cab893eaf55fc5d043": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "367f7a169ad046b898fa663ea9a8f8c9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3820cc1ef13249b581624583c3f4cfe0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "393e6f57e2b9490190b2610ec1e57b8b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3cd7ad04b9e442e28018e9848e1d7b20": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3d0b80684dd3499686016a6646e78455": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3dc589b0425a4f6797203f5c94ff0d1c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3cd7ad04b9e442e28018e9848e1d7b20",
+       "style": "IPY_MODEL_4e4290a014104c3bb95c0e1e1fa2fe23",
+       "value": "%px: 100%"
+      }
+     },
+     "42f28a75108e45569f0c97ca33c6ed5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "46a5ba4719fd43cca83a08325867679f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4e4290a014104c3bb95c0e1e1fa2fe23": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "57c522897432474696e485348ceedba6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "57db5fae55984f529f87b20d41374e12": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "57f157e4e70e4d6f968529322aceddd7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "592d0ec1847c4ffbb604752371efa6e7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b02e10dfa364c35bccd3bb82136091f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5bc356c4026c4de4be482b95741fb792": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5befaa01203642e69e5b27eafc333ed7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5e30acd834ff43a99619e7fea5d37151": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fcbb923f85914e2487eaa8743934e557",
+        "IPY_MODEL_ec34396cb3ac418c8a6c2179908df664",
+        "IPY_MODEL_bf829f1b12fc4f998cdb848cc59ac146"
+       ],
+       "layout": "IPY_MODEL_cfd7df1c0fd946899fcb3331f7374685"
+      }
+     },
+     "60607980bd044458a39ca66516869796": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_704edad021c343fdbe8befda2c757cb2",
+       "max": 1000,
+       "style": "IPY_MODEL_9f71ef0c9c46459abd81041cfea1760d",
+       "value": 1000
+      }
+     },
+     "611f14f2d026492599430823e18aea7b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6143f4a289e34392bf7e9d6c7eb6e828": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "644d67c91ed644c1b8666283f9e3e44a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6546aafd9c42445d90190eb3d43aded1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_592d0ec1847c4ffbb604752371efa6e7",
+       "style": "IPY_MODEL_367f7a169ad046b898fa663ea9a8f8c9",
+       "value": "Rank 3"
+      }
+     },
+     "697cf15dec6447beaa227add1fa986e8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "rank 1: 10/10",
+       "layout": "IPY_MODEL_7ac38bc314734d37abf46c8f14c42088",
+       "max": 10,
+       "style": "IPY_MODEL_7ca37c151d0041b696809cf52167eb21",
+       "value": 10
+      }
+     },
+     "6ac1b87a9d7443dbb5643d723ccdd1a2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "step",
+       "layout": "IPY_MODEL_7614e603250b467f8193c817b5832a76",
+       "style": "IPY_MODEL_74aae5d5c13f4b76a9a8644554a156c3"
+      }
+     },
+     "6b93a729df9e4e9ea719a16bd118403c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "6cfa96031e0d4f72a04800bc51ab3efd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d71463753014446d9f6e851812e4512a",
+       "style": "IPY_MODEL_97ff57a3a45249bab723c0ef78fbc3f7",
+       "value": " 4/4 [00:03&lt;00:00,  1.31tasks/s]"
+      }
+     },
+     "704edad021c343fdbe8befda2c757cb2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "71644963dbf140ed85f1c7f9f4d4eb85": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_d0702b0bdbe84eaba3b964eae2cce492",
+        "IPY_MODEL_250d9258401b416f9f9cdcdc00536be8",
+        "IPY_MODEL_037c70991034492fae395a3cb40eb8d6"
+       ],
+       "layout": "IPY_MODEL_611f14f2d026492599430823e18aea7b"
+      }
+     },
+     "7377456ee3674e019f10851fdc0b701b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "step",
+       "layout": "IPY_MODEL_dda87166c5994d2190a9cdb511dc5b5b",
+       "style": "IPY_MODEL_d7594231736e432780ccb6e9a1901633"
+      }
+     },
+     "73ca808f044b4d9791c8e4a60b7fdc02": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "74aae5d5c13f4b76a9a8644554a156c3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "7614e603250b467f8193c817b5832a76": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7a234f7513a44653bb6f1af60b3cd0aa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7ac38bc314734d37abf46c8f14c42088": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7ca37c151d0041b696809cf52167eb21": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "895b5fe1999f46caac4fdf31cf275a2f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8b5a926621464ea6b80340ee995822b9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8b5ac39bd6114df9b1820ff1402e5a6c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3dc589b0425a4f6797203f5c94ff0d1c",
+        "IPY_MODEL_c4de0e5a98964063aaa3bf9ab56202d8",
+        "IPY_MODEL_cf9747112a614149b432f106877469f8"
+       ],
+       "layout": "IPY_MODEL_9b9d14c066fd4924987dfddfc70de1f5"
+      }
+     },
+     "8c30b37e3f304b168a6b35a48285fdc9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8c67bbc923d0435dab3969e6b4542da2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "901a768152f047948bd294576d49562f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "909e6de0b196405e8f01a0ad14078dde": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6143f4a289e34392bf7e9d6c7eb6e828",
+       "style": "IPY_MODEL_16412eeced9d4f83bb0ad07f1617f226",
+       "value": " 4/4 [00:06&lt;00:00,  6.17s/engine]"
+      }
+     },
+     "9275ed69f6da4d6da5cda1f03ceaeae7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "description": "0 / 5",
+       "layout": "IPY_MODEL_393e6f57e2b9490190b2610ec1e57b8b",
+       "max": 5,
+       "style": "IPY_MODEL_73ca808f044b4d9791c8e4a60b7fdc02"
+      }
+     },
+     "943e9e7d31fe486d874035dd95eea3e8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_d72b90f82c1641d6b85a31af416f034b",
+       "max": 4,
+       "style": "IPY_MODEL_8c30b37e3f304b168a6b35a48285fdc9",
+       "value": 4
+      }
+     },
+     "97f66a2ae82744c7b0c25714ff6c801d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "97ff57a3a45249bab723c0ef78fbc3f7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9b9d14c066fd4924987dfddfc70de1f5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9eda35d7d1274f39b2cd8b3cc21680c6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9f71ef0c9c46459abd81041cfea1760d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a1298fd926004f28a643cf0cbfcc7212": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a32c637d149d402b906812e53cb512e3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a34e597ffc1c41e0b840d563817266d6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_5b02e10dfa364c35bccd3bb82136091f",
+       "max": 4,
+       "style": "IPY_MODEL_ff05e9d0519c43fb8d6231feb4578948",
+       "value": 4
+      }
+     },
+     "a39001310190478b826bfe3280cf72c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e5eae1661d1e40508641f8a6104dffd4",
+       "style": "IPY_MODEL_644d67c91ed644c1b8666283f9e3e44a",
+       "value": "%px: 100%"
+      }
+     },
+     "a5abe771394f4685a305ac5cb1820031": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "a793326d37bc46cc8b8ec74b85bd397e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "description": "0 / 5",
+       "layout": "IPY_MODEL_f0a8f9d531a44dce8a7ee1f555844bc7",
+       "max": 5,
+       "style": "IPY_MODEL_e8881b38fedf4a349ea04b31f2659f76"
+      }
+     },
+     "a865096cd77c477f8eff5c5aa57eddc6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6546aafd9c42445d90190eb3d43aded1",
+        "IPY_MODEL_c544a12559d2440dad524fa859768ffe",
+        "IPY_MODEL_a956517fc0204275a438f7bd2748780a"
+       ],
+       "layout": "IPY_MODEL_8c67bbc923d0435dab3969e6b4542da2"
+      }
+     },
+     "a956517fc0204275a438f7bd2748780a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "description": "0 / 5",
+       "layout": "IPY_MODEL_46a5ba4719fd43cca83a08325867679f",
+       "max": 5,
+       "style": "IPY_MODEL_895b5fe1999f46caac4fdf31cf275a2f"
+      }
+     },
+     "a9a9c8b0d3114bd3a496b9c446b5764c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_19f9886da8f8414aab48f48cedf310d5",
+       "style": "IPY_MODEL_fe1cc858aced41b680160348ccfa4587",
+       "value": "&lt;lambda&gt;: 100%"
+      }
+     },
+     "a9aa033511a943b489e2152ee2e89d9f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ad7a5a35090f41b6a9718ccd8467433b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b0c3f65258a1451384894c1562d84304": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b40297afd3a3495eb1145dbe9e313c5b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_e1105553b0154d368819ed71ebbd1da1",
+        "IPY_MODEL_6ac1b87a9d7443dbb5643d723ccdd1a2",
+        "IPY_MODEL_9275ed69f6da4d6da5cda1f03ceaeae7"
+       ],
+       "layout": "IPY_MODEL_cfef83215abc4fba9b9161819f67c8ba"
+      }
+     },
+     "b73213ba3e914925aecdf1b851a77787": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bf829f1b12fc4f998cdb848cc59ac146": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "description": "0 / 5",
+       "layout": "IPY_MODEL_31130a5903db4d18be96133232804eb7",
+       "max": 5,
+       "style": "IPY_MODEL_36571c1f44e840cab893eaf55fc5d043"
+      }
+     },
+     "bfc1523ebad94dd4803a675a8c54b812": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c3d7769407dc4327b0482995d27ea1c3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e3260332107241079a79e911dcc0bee4",
+       "style": "IPY_MODEL_fa7e766936ac4d31a5184a986fbcf91a",
+       "value": "100%"
+      }
+     },
+     "c4de0e5a98964063aaa3bf9ab56202d8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_901a768152f047948bd294576d49562f",
+       "max": 4,
+       "style": "IPY_MODEL_7a234f7513a44653bb6f1af60b3cd0aa",
+       "value": 4
+      }
+     },
+     "c544a12559d2440dad524fa859768ffe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "step",
+       "layout": "IPY_MODEL_082e905b07184530818bc123fb63fc28",
+       "style": "IPY_MODEL_6b93a729df9e4e9ea719a16bd118403c"
+      }
+     },
+     "cc413de6a5964e9bb353b93bd2730f52": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a39001310190478b826bfe3280cf72c7",
+        "IPY_MODEL_943e9e7d31fe486d874035dd95eea3e8",
+        "IPY_MODEL_6cfa96031e0d4f72a04800bc51ab3efd"
+       ],
+       "layout": "IPY_MODEL_b0c3f65258a1451384894c1562d84304"
+      }
+     },
+     "cc7a6cea16974b7fa13414459c2900ff": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cec37db835eb4d7fb13b0d6ec136d80b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a9aa033511a943b489e2152ee2e89d9f",
+       "style": "IPY_MODEL_d2e50d1359eb4de4bf9055af94425654",
+       "value": " 1000/1000 [00:04&lt;00:00, 203.95tasks/s]"
+      }
+     },
+     "cf9747112a614149b432f106877469f8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0ca8257a5de4422baf18653d3eaaabb0",
+       "style": "IPY_MODEL_e8e83ab91e4e471b96ce8c75d856bb8f",
+       "value": " 4/4 [00:03&lt;00:00,  2.34tasks/s]"
+      }
+     },
+     "cfd7df1c0fd946899fcb3331f7374685": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cfef83215abc4fba9b9161819f67c8ba": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d0702b0bdbe84eaba3b964eae2cce492": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8b5a926621464ea6b80340ee995822b9",
+       "style": "IPY_MODEL_97f66a2ae82744c7b0c25714ff6c801d",
+       "value": "%px: 100%"
+      }
+     },
+     "d2e50d1359eb4de4bf9055af94425654": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d71463753014446d9f6e851812e4512a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d72b90f82c1641d6b85a31af416f034b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d7594231736e432780ccb6e9a1901633": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "d7b6802ae7f7406fa273c7438386bb36": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dc484bcad62146f2a81c96678472b60a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dd5ef98076d94493b57b021455162c56": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "rank 0: 10/10",
+       "layout": "IPY_MODEL_a32c637d149d402b906812e53cb512e3",
+       "max": 10,
+       "style": "IPY_MODEL_3d0b80684dd3499686016a6646e78455",
+       "value": 10
+      }
+     },
+     "dda87166c5994d2190a9cdb511dc5b5b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dfdbae12208c47ea98ef749d45d64f62": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c3d7769407dc4327b0482995d27ea1c3",
+        "IPY_MODEL_a34e597ffc1c41e0b840d563817266d6",
+        "IPY_MODEL_909e6de0b196405e8f01a0ad14078dde"
+       ],
+       "layout": "IPY_MODEL_ebcbcc562ad74db6860bf8067e7226be"
+      }
+     },
+     "e02c6493e62e4ed38d2dfd45b7115667": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "rank 3: 10/10",
+       "layout": "IPY_MODEL_0fc04d1691c54db2907ebdd0cfb77b0f",
+       "max": 10,
+       "style": "IPY_MODEL_fd90a574743f495da2b44bbd4f5ccf1b",
+       "value": 10
+      }
+     },
+     "e1105553b0154d368819ed71ebbd1da1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_dc484bcad62146f2a81c96678472b60a",
+       "style": "IPY_MODEL_ad7a5a35090f41b6a9718ccd8467433b",
+       "value": "Rank 0"
+      }
+     },
+     "e3260332107241079a79e911dcc0bee4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e5eae1661d1e40508641f8a6104dffd4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e8881b38fedf4a349ea04b31f2659f76": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e8e83ab91e4e471b96ce8c75d856bb8f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ebcbcc562ad74db6860bf8067e7226be": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ec34396cb3ac418c8a6c2179908df664": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "step",
+       "layout": "IPY_MODEL_3820cc1ef13249b581624583c3f4cfe0",
+       "style": "IPY_MODEL_a5abe771394f4685a305ac5cb1820031"
+      }
+     },
+     "f0a8f9d531a44dce8a7ee1f555844bc7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fa7e766936ac4d31a5184a986fbcf91a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fcbb923f85914e2487eaa8743934e557": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_5bc356c4026c4de4be482b95741fb792",
+       "style": "IPY_MODEL_fd10d6b5d9c3446685d59a5d0ee1dc1b",
+       "value": "Rank 1"
+      }
+     },
+     "fd10d6b5d9c3446685d59a5d0ee1dc1b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fd90a574743f495da2b44bbd4f5ccf1b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fe1cc858aced41b680160348ccfa4587": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ff05e9d0519c43fb8d6231feb4578948": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -43,7 +43,7 @@ def check_ready(f, self, *args, **kwargs):
     """Check ready state prior to calling the method."""
     self.wait(0)
     if not self._ready:
-        raise error.TimeoutError("result not ready")
+        raise TimeoutError("result not ready")
     return f(self, *args, **kwargs)
 
 
@@ -236,11 +236,11 @@ class AsyncResult(Future):
                 else:
                     raise e
         else:
-            raise error.TimeoutError("Result not ready.")
+            raise TimeoutError("Result not ready.")
 
     def _check_ready(self):
         if not self.ready():
-            raise error.TimeoutError("Result not ready.")
+            raise TimeoutError("Result not ready.")
 
     def ready(self):
         """Return whether the call has completed."""
@@ -430,12 +430,12 @@ class AsyncResult(Future):
                 # Event doesn't like timeout < 0
                 timeout = None
             elif timeout == 0:
-                raise error.TimeoutError("Still waiting to be sent")
+                raise TimeoutError("Still waiting to be sent")
             # wait for Future to indicate send having been called,
             # which means MessageTracker is ready.
             tic = time.time()
             if not self._sent_event.wait(timeout):
-                raise error.TimeoutError("Still waiting to be sent")
+                raise TimeoutError("Still waiting to be sent")
             if timeout:
                 timeout = max(0, timeout - (time.time() - tic))
         try:
@@ -444,7 +444,7 @@ class AsyncResult(Future):
                 timeout = -1
             return self._tracker.wait(timeout)
         except zmq.NotDone:
-            raise error.TimeoutError("Still waiting to be sent")
+            raise TimeoutError("Still waiting to be sent")
 
     # -------------------------------------
     # dict-access
@@ -477,7 +477,7 @@ class AsyncResult(Future):
         """getattr maps to getitem for convenient attr access to metadata."""
         try:
             return self.__getitem__(key)
-        except (error.TimeoutError, KeyError):
+        except (TimeoutError, KeyError):
             raise AttributeError(
                 "%r object has no attribute %r" % (self.__class__.__name__, key)
             )
@@ -497,7 +497,7 @@ class AsyncResult(Future):
             raise TypeError("AsyncResults with a single result are not iterable.")
         try:
             rlist = self.get(0)
-        except error.TimeoutError:
+        except TimeoutError:
             # wait for each result individually
             evt = Event()
             for child in self._children:
@@ -849,7 +849,7 @@ class AsyncMapResult(AsyncResult):
         """iterator for results *as they arrive*, preserving submission order."""
         try:
             rlist = self.get(0)
-        except error.TimeoutError:
+        except TimeoutError:
             # wait for each result individually
             evt = Event()
             for child in self._children:
@@ -866,7 +866,7 @@ class AsyncMapResult(AsyncResult):
         """iterator for results *as they arrive*, on FCFS basis, ignoring submission order."""
         try:
             rlist = self.get(0)
-        except error.TimeoutError:
+        except TimeoutError:
             queue = Queue()
             for child in self._children:
                 child.add_done_callback(queue.put)

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -726,7 +726,7 @@ class Client(HasTraits):
         # poll expects milliseconds, timeout is seconds
         evts = poller.poll(timeout * 1000)
         if not evts:
-            raise error.TimeoutError("Hub connection request timed out")
+            raise TimeoutError("Hub connection request timed out")
         idents, msg = self.session.recv(self._query_socket, mode=0)
         if self.debug:
             pprint(msg)

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -12,6 +12,7 @@ import types
 import warnings
 from collections.abc import Iterable
 from concurrent.futures import Future
+from functools import partial
 from getpass import getpass
 from pprint import pprint
 from threading import current_thread
@@ -21,6 +22,7 @@ from threading import Thread
 import jupyter_client.session
 import zmq
 from decorator import decorator
+from ipykernel.comm import Comm
 from IPython import get_ipython
 from IPython.core.application import BaseIPythonApplication
 from IPython.core.profiledir import ProfileDir
@@ -1077,6 +1079,8 @@ class Client(HasTraits):
         # init metadata:
         md = self.metadata[msg_id]
 
+        ip = get_ipython()
+
         if msg_type == 'stream':
             name = content['name']
             s = md[name] or ''
@@ -1099,9 +1103,54 @@ class Client(HasTraits):
                 if future and not future.done():
                     # TODO: should probably store actual outputs on the Future
                     future.set_result(None)
-        else:
-            # unhandled msg_type (status, etc.)
-            pass
+        elif msg_type.startswith("comm_") and ip is not None and ip.kernel is not None:
+            # only handle comm messages when we're in an IPython kernel
+            if msg_type == "comm_open":
+                # create proxy comm
+                engine_uuid = msg['metadata'].get('engine', '')
+                engine_ident = engine_uuid.encode("utf8", "replace")
+                # DEBUG: engine_uuid can still be missing?!
+
+                comm = Comm(
+                    comm_id=content['comm_id'],
+                    primary=False,
+                )
+
+                send_to_engine = partial(
+                    self._send,
+                    self._mux_socket,
+                    ident=engine_ident,
+                )
+
+                def relay_comm(msg):
+                    send_to_engine(
+                        msg["msg_type"],
+                        content=msg['content'],
+                        metadata=msg['metadata'],
+                        buffers=msg["buffers"],
+                    )
+
+                comm.on_msg(relay_comm)
+                comm.on_close(
+                    lambda: send_to_engine(
+                        "comm_close",
+                        content={
+                            "comm_id": comm.comm_id,
+                        },
+                    )
+                )
+                ip.kernel.comm_manager.register_comm(comm)
+
+            # relay all comm msgs
+            ip.kernel.session.send(
+                ip.kernel.iopub_socket,
+                msg_type,
+                content=msg['content'],
+                metadata=msg['metadata'],
+                buffers=msg['buffers'],
+                # different parent!
+                parent=ip.kernel.get_parent("shell"),
+            )
 
         msg_future = self._futures.get(msg_id, None)
         if msg_future:
@@ -1148,7 +1197,9 @@ class Client(HasTraits):
         )
         msg_id = msg['header']['msg_id']
 
-        if track_outstanding:
+        expect_reply = msg_type not in {"comm_msg", "comm_close", "comm_open"}
+
+        if expect_reply and track_outstanding:
             # add to outstanding, history
             self.outstanding.add(msg_id)
             self.history.append(msg_id)
@@ -1164,22 +1215,23 @@ class Client(HasTraits):
                     self._outstanding_dict[ident_str].add(msg_id)
             self.metadata['submitted'] = util.utcnow()
 
-        futures = self.create_message_futures(
-            msg_id,
-            async_result=msg_type in {'execute_request', 'apply_request'},
-            track=track,
-        )
-        if message_future_hook is not None:
-            message_future_hook(futures[0])
+        if expect_reply:
+            futures = self.create_message_futures(
+                msg_id,
+                async_result=msg_type in {'execute_request', 'apply_request'},
+                track=track,
+            )
+            if message_future_hook is not None:
+                message_future_hook(futures[0])
 
-        def cleanup(f):
-            """Purge caches on Future resolution"""
-            self.results.pop(msg_id, None)
-            self._futures.pop(msg_id, None)
-            self._output_futures.pop(msg_id, None)
-            self.metadata.pop(msg_id, None)
+            def cleanup(f):
+                """Purge caches on Future resolution"""
+                self.results.pop(msg_id, None)
+                self._futures.pop(msg_id, None)
+                self._output_futures.pop(msg_id, None)
+                self.metadata.pop(msg_id, None)
 
-        multi_future(futures).add_done_callback(cleanup)
+            multi_future(futures).add_done_callback(cleanup)
 
         def _really_send():
             sent = self.session.send(
@@ -1190,7 +1242,8 @@ class Client(HasTraits):
 
         # hand off actual send to IO thread
         self._io_loop.add_callback(_really_send)
-        return futures[0]
+        if expect_reply:
+            return futures[0]
 
     def _send_recv(self, *args, **kwargs):
         """Send a message in the IO thread and return its reply"""

--- a/ipyparallel/error.py
+++ b/ipyparallel/error.py
@@ -8,6 +8,7 @@ Inheritance diagram:
 """
 from __future__ import print_function
 
+import builtins
 import sys
 import traceback
 
@@ -49,8 +50,8 @@ class TaskTimeout(KernelError):
     pass
 
 
-class TimeoutError(KernelError):
-    pass
+# backward-compat: use builtin TimeoutError, but preserve `error.TimeoutError` import
+TimeoutError = builtins.TimeoutError
 
 
 class UnmetDependency(KernelError):

--- a/ipyparallel/tests/test_asyncresult.py
+++ b/ipyparallel/tests/test_asyncresult.py
@@ -10,7 +10,6 @@ import ipyparallel as ipp
 from .clienttest import ClusterTestCase
 from .clienttest import raises_remote
 from ipyparallel import error
-from ipyparallel.error import TimeoutError
 
 
 def wait(n):
@@ -358,7 +357,7 @@ class AsyncResultTest(ClusterTestCase):
     def test_wait_for_send(self):
         view = self.client[-1]
         view.track = True
-        with self.assertRaises(error.TimeoutError):
+        with self.assertRaises(TimeoutError):
             # this test can fail if the send happens too quickly
             # e.g. the IO thread takes control for too long,
             # so run the test a few times


### PR DESCRIPTION
adds reasonably complete support for relaying comm messages between engines and clients, thereby enabling the creation of widgets on engines for internal-task progress.

![parallel-progress](https://user-images.githubusercontent.com/151929/133263498-c9b3e22d-e097-425f-adcb-d60b37df00bc.gif)

closes #587 
closes #585 