### PR TITLE
add single Cluster.start_and_connect

### DIFF
--- a/docs/source/examples/Cluster API.ipynb
+++ b/docs/source/examples/Cluster API.ipynb
@@ -934,7 +934,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/examples/Futures.ipynb
+++ b/docs/source/examples/Futures.ipynb
@@ -26,7 +26,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "92d10137a54248ea989bcef12e0d9160",
+       "model_id": "107792592f044155ab2d9dec950ca6e7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -50,10 +50,8 @@
    ],
    "source": [
     "import ipyparallel as ipp\n",
-    "cluster = ipp.Cluster()\n",
-    "cluster.start_cluster_sync()\n",
-    "rc = cluster.connect_client_sync()\n",
-    "rc.wait_for_engines(4)\n",
+    "rc = ipp.Cluster(n=4).start_and_connect_sync()\n",
+    "\n",
     "dv = rc[:]\n",
     "dv.activate()\n",
     "dv"
@@ -625,72 +623,40 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "01a0b3206baf44f4bded78fc3130b4ec": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "1a2ac7bdd26b4bf480036118d4fa611b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "202ff05b7a094c0193c6697b74f3974f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_1a2ac7bdd26b4bf480036118d4fa611b",
-       "max": 4,
-       "style": "IPY_MODEL_01a0b3206baf44f4bded78fc3130b4ec",
-       "value": 4
-      }
-     },
-     "743a4996fdaf40408ca21d2ae59638dc": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_cb803ea8b4fc4b069dbf0de3fac56981",
-       "style": "IPY_MODEL_abe1338081fb48f1a2a9060a53ff30fe",
-       "value": "100%"
-      }
-     },
-     "7a1d39aed4bc487dbe02b28d404ca2ff": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_8dccde6b9f0e41bda875ac6170182f38",
-       "style": "IPY_MODEL_eeb1b09cc3c34c1fbfb3ff78af2d9511",
-       "value": " 4/4 [00:03&lt;00:00,  3.67s/engine]"
-      }
-     },
-     "8dccde6b9f0e41bda875ac6170182f38": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "92d10137a54248ea989bcef12e0d9160": {
+     "107792592f044155ab2d9dec950ca6e7": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
       "state": {
        "children": [
-        "IPY_MODEL_743a4996fdaf40408ca21d2ae59638dc",
-        "IPY_MODEL_202ff05b7a094c0193c6697b74f3974f",
-        "IPY_MODEL_7a1d39aed4bc487dbe02b28d404ca2ff"
+        "IPY_MODEL_2d6218bb526d44f0acda723f0c6dc861",
+        "IPY_MODEL_acda3a9b8ac74e12bfcc6408aa8b11ad",
+        "IPY_MODEL_30dc8b7299de4c6f869fa41aebba7f45"
        ],
-       "layout": "IPY_MODEL_dad961a3786e4b16a413832e13f2a82e"
+       "layout": "IPY_MODEL_412b13dee37849cd97baf8ab5f0552f3"
       }
      },
-     "abe1338081fb48f1a2a9060a53ff30fe": {
+     "2d6218bb526d44f0acda723f0c6dc861": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a17b92b8857c4bd5b883c5615021c713",
+       "style": "IPY_MODEL_fd97190cd7094a429ec44137db60db39",
+       "value": "100%"
+      }
+     },
+     "30dc8b7299de4c6f869fa41aebba7f45": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8783cf96737d4e03a7dd05208445afe1",
+       "style": "IPY_MODEL_398a5bd036a643fc9be7e97200b091e3",
+       "value": " 4/4 [00:04&lt;00:00,  4.75s/engine]"
+      }
+     },
+     "398a5bd036a643fc9be7e97200b091e3": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -698,19 +664,51 @@
        "description_width": ""
       }
      },
-     "cb803ea8b4fc4b069dbf0de3fac56981": {
+     "412b13dee37849cd97baf8ab5f0552f3": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "dad961a3786e4b16a413832e13f2a82e": {
+     "8783cf96737d4e03a7dd05208445afe1": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "eeb1b09cc3c34c1fbfb3ff78af2d9511": {
+     "97f0bee4e8c64f608146df6c4b9e30c0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a17b92b8857c4bd5b883c5615021c713": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "acda3a9b8ac74e12bfcc6408aa8b11ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_c80f0d14fe6542e0b25385efb22e54e5",
+       "max": 4,
+       "style": "IPY_MODEL_97f0bee4e8c64f608146df6c4b9e30c0",
+       "value": 4
+      }
+     },
+     "c80f0d14fe6542e0b25385efb22e54e5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fd97190cd7094a429ec44137db60db39": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",

--- a/docs/source/examples/Monitoring an MPI Simulation - 1.ipynb
+++ b/docs/source/examples/Monitoring an MPI Simulation - 1.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {
     "slideshow": {
      "slide_start": false
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -45,15 +45,13 @@
      "output_type": "stream",
      "text": [
       "Using existing profile dir: '/Users/minrk/.ipython/profile_default'\n",
-      "Sending output for ipcontroller-1630326312-jeow-45984 to /Users/minrk/.ipython/profile_default/log/ipcontroller-1630326312-jeow-45984.log\n",
-      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
-      "Sending output for ipengine-1630326312-jeow-1630326314-45984 to /Users/minrk/.ipython/profile_default/log/ipengine-1630326312-jeow-1630326314-45984.log\n"
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4673e92bcc504a1c83fc4b3b0a3a578b",
+       "model_id": "8b14b3b6f0cb4a67be4645c8274c4074",
        "version_major": 2,
        "version_minor": 0
       },
@@ -70,7 +68,7 @@
        "[0, 1, 2, 3]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -79,10 +77,7 @@
     "import ipyparallel as ipp\n",
     "n = 4\n",
     "\n",
-    "cluster = ipp.Cluster(engine_launcher_class=\"mpi\", n=n)\n",
-    "cluster.start_cluster_sync()\n",
-    "rc = cluster.connect_client_sync()\n",
-    "rc.wait_for_engines(n=n)\n",
+    "rc = ipp.Cluster(engine_launcher_class=\"mpi\", n=n).start_and_connect_sync()\n",
     "\n",
     "view = rc[:]\n",
     "rc.ids"
@@ -572,157 +567,165 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "0c708dd3689e4415b161b27dc8c0f9bf": {
+     "02f2d94254d542bdbd3cff7f9bc035e7": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "FloatProgressModel",
       "state": {
        "bar_style": "success",
-       "layout": "IPY_MODEL_2f22813ac0404a909f54361add9cbd38",
+       "layout": "IPY_MODEL_4cdefd8ae5764be8a8bf1f3c374492f0",
        "max": 4,
-       "style": "IPY_MODEL_b297e859bfb44e49964b5567e714bd84",
+       "style": "IPY_MODEL_d101b978f358462fbcc0ad51c4be1ee1",
        "value": 4
       }
      },
-     "13d79f99f53e4778bee174c0d35289b6": {
+     "0ab41c84c30445dfa2c77e0e2014dd46": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "15ccabba1e60481f93024a6b574982ab": {
+     "11097de7cc114cc88d99cd17a693d510": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "204a15b67141469d955343fc1309e90d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "2f22813ac0404a909f54361add9cbd38": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "3aedb3428bbf413b890f37a5c58556ed": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_13d79f99f53e4778bee174c0d35289b6",
-       "max": 4,
-       "style": "IPY_MODEL_a9663d614bcb439eaa56aec8d5a26d78",
-       "value": 4
-      }
-     },
-     "4673e92bcc504a1c83fc4b3b0a3a578b": {
+     "20d1375897eb4fdcb87fda73573ad678": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
       "state": {
        "children": [
-        "IPY_MODEL_edeaaa5d9dbb43d6a9c7200346517fd6",
-        "IPY_MODEL_69a098a3bb2d47d6b04f771e534b1a91",
-        "IPY_MODEL_5c0f7a031878414794e4b6a2b48a509c"
+        "IPY_MODEL_7a50e71a222340a4ba51e70ef3abce47",
+        "IPY_MODEL_02f2d94254d542bdbd3cff7f9bc035e7",
+        "IPY_MODEL_876517d46fa6488f8fb61db3ed689b96"
        ],
-       "layout": "IPY_MODEL_60cf5f1d2d8b46788766a629671e5a4b"
+       "layout": "IPY_MODEL_0ab41c84c30445dfa2c77e0e2014dd46"
       }
      },
-     "47805efa023e45528ac39161e87bb59e": {
+     "212854fc12af402eb3a57438a851dfac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2231573544774560984193c60e6370cb": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "565a738c68464a1da598f95e1624316d": {
+     "4205fec62aea485c8ffaf31ca98859aa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4cdefd8ae5764be8a8bf1f3c374492f0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5143e78c3dcc439a95b7ec24ea37c2be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6817e30d6c824bd194e102e20a9e7cda": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6be3837161754e08a715ac0c78fa1080": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7a50e71a222340a4ba51e70ef3abce47": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
       "state": {
-       "layout": "IPY_MODEL_fba124a16ef844cc846dd95a92296a2d",
-       "style": "IPY_MODEL_d35f91df913945d1ad8637bb90e9e34c",
+       "layout": "IPY_MODEL_2231573544774560984193c60e6370cb",
+       "style": "IPY_MODEL_6817e30d6c824bd194e102e20a9e7cda",
        "value": "100%"
       }
      },
-     "5c0f7a031878414794e4b6a2b48a509c": {
+     "7afda4d37ef841c684bb624ff6b19267": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "layout": "IPY_MODEL_5d418a0efbb84b90bf6627bae52f1f0e",
-       "style": "IPY_MODEL_ee283fd6d2cb47fb9bf91500968791d2",
-       "value": " 4/4 [00:08&lt;00:00,  8.90s/engine]"
+       "description_width": ""
       }
      },
-     "5d418a0efbb84b90bf6627bae52f1f0e": {
+     "811e5930f3bc42899a5e700d9b275bdb": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "60cf5f1d2d8b46788766a629671e5a4b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "69a098a3bb2d47d6b04f771e534b1a91": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_dba47740faf249529510efafdc85aa56",
-       "max": 4,
-       "style": "IPY_MODEL_97c1ddb39a704b08a5968d28a6eff758",
-       "value": 4
-      }
-     },
-     "7c791801e9bf429fafffb48c28a1632f": {
+     "876517d46fa6488f8fb61db3ed689b96": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
       "state": {
-       "layout": "IPY_MODEL_204a15b67141469d955343fc1309e90d",
-       "style": "IPY_MODEL_c71775a7a08a4debac75a7a4ac6dae51",
-       "value": " 4/4 [00:08&lt;00:00,  8.70s/engine]"
+       "layout": "IPY_MODEL_11097de7cc114cc88d99cd17a693d510",
+       "style": "IPY_MODEL_7afda4d37ef841c684bb624ff6b19267",
+       "value": " 4/4 [00:05&lt;00:00,  5.54s/engine]"
       }
      },
-     "7d810b0a3d594aadaca04d1229b2664b": {
+     "88e7ff230d284b368ace25166967a93d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6be3837161754e08a715ac0c78fa1080",
+       "style": "IPY_MODEL_5143e78c3dcc439a95b7ec24ea37c2be",
+       "value": "100%"
+      }
+     },
+     "8b14b3b6f0cb4a67be4645c8274c4074": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
       "state": {
        "children": [
-        "IPY_MODEL_875a870565c14c57ab223b0077ff4455",
-        "IPY_MODEL_0c708dd3689e4415b161b27dc8c0f9bf",
-        "IPY_MODEL_a8c78141374d440390bda874d6d9f504"
+        "IPY_MODEL_88e7ff230d284b368ace25166967a93d",
+        "IPY_MODEL_eee11ad7360e4cc2b6b2f196ff4a1d45",
+        "IPY_MODEL_9d0e878210c24c93bc764ec9ec53b84e"
        ],
-       "layout": "IPY_MODEL_47805efa023e45528ac39161e87bb59e"
+       "layout": "IPY_MODEL_a15b2b7fec55486689859c321b2ca7e3"
       }
      },
-     "875a870565c14c57ab223b0077ff4455": {
+     "9d0e878210c24c93bc764ec9ec53b84e": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
       "state": {
-       "layout": "IPY_MODEL_d4c14be570444871bd676908cc031872",
-       "style": "IPY_MODEL_b43c6a7ae21c46dea252f732477d7505",
-       "value": "100%"
+       "layout": "IPY_MODEL_811e5930f3bc42899a5e700d9b275bdb",
+       "style": "IPY_MODEL_212854fc12af402eb3a57438a851dfac",
+       "value": " 4/4 [00:06&lt;00:00,  6.12s/engine]"
       }
      },
-     "92b195c62f0649a1aeee28effec049ab": {
+     "a15b2b7fec55486689859c321b2ca7e3": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "97c1ddb39a704b08a5968d28a6eff758": {
+     "afa1055878c444c49c4db6767994e04b": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "ProgressStyleModel",
@@ -730,17 +733,7 @@
        "description_width": ""
       }
      },
-     "a8c78141374d440390bda874d6d9f504": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_c84eaf0671c144738294b49679e026a6",
-       "style": "IPY_MODEL_f44b789f89954f1298bd7a2266f672a7",
-       "value": " 4/4 [00:08&lt;00:00,  8.99s/engine]"
-      }
-     },
-     "a9663d614bcb439eaa56aec8d5a26d78": {
+     "d101b978f358462fbcc0ad51c4be1ee1": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "ProgressStyleModel",
@@ -748,108 +741,17 @@
        "description_width": ""
       }
      },
-     "b207fc25ff0344c18f36a5f7bb8aff11": {
+     "eee11ad7360e4cc2b6b2f196ff4a1d45": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
+      "model_name": "FloatProgressModel",
       "state": {
-       "description_width": ""
+       "bar_style": "success",
+       "layout": "IPY_MODEL_4205fec62aea485c8ffaf31ca98859aa",
+       "max": 4,
+       "style": "IPY_MODEL_afa1055878c444c49c4db6767994e04b",
+       "value": 4
       }
-     },
-     "b297e859bfb44e49964b5567e714bd84": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "b43c6a7ae21c46dea252f732477d7505": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "c71775a7a08a4debac75a7a4ac6dae51": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "c84eaf0671c144738294b49679e026a6": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "d35f91df913945d1ad8637bb90e9e34c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "d4c14be570444871bd676908cc031872": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "dba47740faf249529510efafdc85aa56": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "edeaaa5d9dbb43d6a9c7200346517fd6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_92b195c62f0649a1aeee28effec049ab",
-       "style": "IPY_MODEL_b207fc25ff0344c18f36a5f7bb8aff11",
-       "value": "100%"
-      }
-     },
-     "ee283fd6d2cb47fb9bf91500968791d2": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "f17ec833fe0948208ad502709e345f33": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_565a738c68464a1da598f95e1624316d",
-        "IPY_MODEL_3aedb3428bbf413b890f37a5c58556ed",
-        "IPY_MODEL_7c791801e9bf429fafffb48c28a1632f"
-       ],
-       "layout": "IPY_MODEL_15ccabba1e60481f93024a6b574982ab"
-      }
-     },
-     "f44b789f89954f1298bd7a2266f672a7": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "fba124a16ef844cc846dd95a92296a2d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
      }
     },
     "version_major": 2,

--- a/docs/source/examples/Monitoring an MPI Simulation - 2.ipynb
+++ b/docs/source/examples/Monitoring an MPI Simulation - 2.ipynb
@@ -26,15 +26,13 @@
      "output_type": "stream",
      "text": [
       "Using existing profile dir: '/Users/minrk/.ipython/profile_default'\n",
-      "Sending output for ipcontroller-1630326174-s94f-45949 to /Users/minrk/.ipython/profile_default/log/ipcontroller-1630326174-s94f-45949.log\n",
-      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
-      "Sending output for ipengine-1630326174-s94f-1630326175-45949 to /Users/minrk/.ipython/profile_default/log/ipengine-1630326174-s94f-1630326175-45949.log\n"
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa30ee3bb74b4fa0bc634d043af415c0",
+       "model_id": "da09992ca3fd438eadf96a6599d5384e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -48,14 +46,11 @@
    ],
    "source": [
     "import ipyparallel as ipp\n",
+    "\n",
     "n = 4\n",
     "\n",
-    "cluster = ipp.Cluster(engine_launcher_class=\"mpi\", n=n)\n",
-    "cluster.start_cluster_sync()\n",
-    "client = cluster.connect_client_sync()\n",
-    "client.wait_for_engines(n=n)\n",
-    "\n",
-    "view = client[:]\n"
+    "rc = ipp.Cluster(engine_launcher_class=\"mpi\", n=n).start_and_connect_sync()\n",
+    "view = rc[:]"
    ]
   },
   {
@@ -428,7 +423,59 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "329127a401e7474a8983be88a164ae94": {
+     "31b6b4a0105148e187aadfc70e0fe1c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c872eb3aedc4492eb5a7d3b3c24249bb",
+       "style": "IPY_MODEL_7b50ee6a201f48f796c337a68ba8730c",
+       "value": " 4/4 [00:05&lt;00:00,  5.23s/engine]"
+      }
+     },
+     "401e2a9344964c7082435def275db2c8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "650e652f16044e4f816006c8f334eadb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9a56d508e10842299d798de5d18aa84a",
+       "style": "IPY_MODEL_fe5f5baeb0b24e13bfb0aa8e3d411b0b",
+       "value": "100%"
+      }
+     },
+     "7b50ee6a201f48f796c337a68ba8730c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7d5e98d4de4b472080ce751a65546968": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_401e2a9344964c7082435def275db2c8",
+       "max": 4,
+       "style": "IPY_MODEL_a577270a23bf46fa933a41e32d1a5a79",
+       "value": 4
+      }
+     },
+     "9a56d508e10842299d798de5d18aa84a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a577270a23bf46fa933a41e32d1a5a79": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "ProgressStyleModel",
@@ -436,90 +483,38 @@
        "description_width": ""
       }
      },
-     "33b91ff5320245459eeabdeb357f702d": {
+     "bba28e827ace46e9b233476330b76938": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "4411f05b175e4ec987efa9be8b8041c3": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "91eb9084361447bda7a2605ee87b3370": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_faf6f94c7c424519b432574f7cea8b66",
-       "style": "IPY_MODEL_9a9150eb265a461d875e6bf90ea4d540",
-       "value": "100%"
-      }
-     },
-     "9a159781391247efa1830a528a9e99d1": {
+     "c872eb3aedc4492eb5a7d3b3c24249bb": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "9a9150eb265a461d875e6bf90ea4d540": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "b05624569d284e18b26a4b8217511c93": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_e2b878d71fcb45ed80721faae23f660f",
-       "max": 4,
-       "style": "IPY_MODEL_329127a401e7474a8983be88a164ae94",
-       "value": 4
-      }
-     },
-     "be4615abab924593a6652d1802252487": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_9a159781391247efa1830a528a9e99d1",
-       "style": "IPY_MODEL_4411f05b175e4ec987efa9be8b8041c3",
-       "value": " 4/4 [00:11&lt;00:00, 11.87s/engine]"
-      }
-     },
-     "e2b878d71fcb45ed80721faae23f660f": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "fa30ee3bb74b4fa0bc634d043af415c0": {
+     "da09992ca3fd438eadf96a6599d5384e": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
       "state": {
        "children": [
-        "IPY_MODEL_91eb9084361447bda7a2605ee87b3370",
-        "IPY_MODEL_b05624569d284e18b26a4b8217511c93",
-        "IPY_MODEL_be4615abab924593a6652d1802252487"
+        "IPY_MODEL_650e652f16044e4f816006c8f334eadb",
+        "IPY_MODEL_7d5e98d4de4b472080ce751a65546968",
+        "IPY_MODEL_31b6b4a0105148e187aadfc70e0fe1c7"
        ],
-       "layout": "IPY_MODEL_33b91ff5320245459eeabdeb357f702d"
+       "layout": "IPY_MODEL_bba28e827ace46e9b233476330b76938"
       }
      },
-     "faf6f94c7c424519b432574f7cea8b66": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
+     "fe5f5baeb0b24e13bfb0aa8e3d411b0b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
      }
     },
     "version_major": 2,

--- a/docs/source/examples/Parallel Magics.ipynb
+++ b/docs/source/examples/Parallel Magics.ipynb
@@ -24,10 +24,8 @@
    "outputs": [],
    "source": [
     "import ipyparallel as ipp\n",
-    "cluster = ipp.Cluster()\n",
-    "cluster.start_cluster_sync(n=4)\n",
-    "rc = cluster.connect_client_sync()\n",
-    "rc.wait_for_engines(4)\n",
+    "\n",
+    "rc = ipp.Cluster(n=4).start_and_connect_sync()\n",
     "dv = rc[:]\n",
     "rc.ids"
    ]
@@ -490,7 +488,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/examples/dask.ipynb
+++ b/docs/source/examples/dask.ipynb
@@ -55,11 +55,7 @@
    "source": [
     "import ipyparallel as ipp\n",
     "\n",
-    "cluster = ipp.Cluster()\n",
-    "n = 4\n",
-    "await cluster.start_cluster(n)\n",
-    "rc = await cluster.connect_client()\n",
-    "rc.wait_for_engines(n)"
+    "rc = ipp.Cluster(n=4).start_and_connect_sync()"
    ]
   },
   {

--- a/docs/source/examples/joblib.ipynb
+++ b/docs/source/examples/joblib.ipynb
@@ -161,11 +161,7 @@
     }
    ],
    "source": [
-    "cluster = ipp.Cluster()\n",
-    "cluster.start_cluster_sync(4)\n",
-    "\n",
-    "rc = cluster.connect_client_sync()\n",
-    "rc.wait_for_engines(4)\n",
+    "rc = ipp.Cluster(n=4).start_and_connect_sync()\n",
     "\n",
     "rc[:].use_cloudpickle()\n",
     "view = rc.load_balanced_view()\n",

--- a/docs/source/examples/visualizing-tasks.ipynb
+++ b/docs/source/examples/visualizing-tasks.ipynb
@@ -35,7 +35,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c07c235314e9456f9a9c3550404b6cb5",
+       "model_id": "a88e9002f12849979a16528e113e9a54",
        "version_major": 2,
        "version_minor": 0
       },
@@ -48,11 +48,7 @@
     }
    ],
    "source": [
-    "cluster = ipp.Cluster()\n",
-    "n = 8\n",
-    "await cluster.start_cluster(8)\n",
-    "rc = await cluster.connect_client()\n",
-    "rc.wait_for_engines(n)"
+    "rc = await ipp.Cluster().start_and_connect(n=8)\n"
    ]
   },
   {
@@ -642,101 +638,17 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "04834bbfb8d14f12bfeed1a71b47cce6": {
+     "0421d9cb7f9b406d982ee0c005a9a532": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
       "state": {
-       "layout": "IPY_MODEL_91470379e61d4e278e2713096fc29e55",
-       "style": "IPY_MODEL_394dd6f667854c3fb7706e3c81b39bdd",
-       "value": " 256/256 [00:05&lt;00:00, 41.71tasks/s]"
-      }
-     },
-     "049b46d137d143d0849de70535a12ef5": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "118e6a646fe743748a5c2cb00649214a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_d8594e6d653d45e5a85f865676c74765",
-       "style": "IPY_MODEL_049b46d137d143d0849de70535a12ef5",
-       "value": " 8/8 [00:07&lt;00:00,  1.43s/engine]"
-      }
-     },
-     "1e013fe3328e482192d8da7a1e85a06a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_b423bb99df75417e9b389df2ccc09c46",
-       "style": "IPY_MODEL_983e924049ca4d7c91ba88b2f89e4d3d",
-       "value": "work: 100%"
-      }
-     },
-     "203a8e5c66bd40d19ef7abb4609a154b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "394dd6f667854c3fb7706e3c81b39bdd": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "57db957e10254d67936bdfb98ce0f316": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "77cc4198c58d471fa3a9d08fe5e2c16a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "bar_style": "success",
-       "layout": "IPY_MODEL_df8ccfffc9da43d7bd7e02d2222f770b",
-       "max": 8,
-       "style": "IPY_MODEL_a3a553c0d7c1481884ed795ecf055481",
-       "value": 8
-      }
-     },
-     "91282c0c7de941548c6317b5ff049411": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_9b61e40719e34147b75efcd94f76671c",
-       "style": "IPY_MODEL_9a3c1174ebf547de80e44be992c9af62",
+       "layout": "IPY_MODEL_b3cd9eef2db342308a832c022cbb620d",
+       "style": "IPY_MODEL_8fd7b6a17e804c90961d59398b635244",
        "value": "100%"
       }
      },
-     "91470379e61d4e278e2713096fc29e55": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "932c41ad3e444c77b41ffc60e0ab6e60": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "983e924049ca4d7c91ba88b2f89e4d3d": {
+     "2325225341874e0b9cee528398d6424b": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -744,34 +656,13 @@
        "description_width": ""
       }
      },
-     "9a3c1174ebf547de80e44be992c9af62": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "9b13f0b670c64389b846fbc106308f97": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_1e013fe3328e482192d8da7a1e85a06a",
-        "IPY_MODEL_de393bcdcc8c4715912601f723b0e302",
-        "IPY_MODEL_04834bbfb8d14f12bfeed1a71b47cce6"
-       ],
-       "layout": "IPY_MODEL_57db957e10254d67936bdfb98ce0f316"
-      }
-     },
-     "9b61e40719e34147b75efcd94f76671c": {
+     "5109f916201e46279f135d7403112689": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "a3a553c0d7c1481884ed795ecf055481": {
+     "6849ab149d6d41c99fe55794adfc8d23": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "ProgressStyleModel",
@@ -779,54 +670,66 @@
        "description_width": ""
       }
      },
-     "b423bb99df75417e9b389df2ccc09c46": {
+     "7ba86883f6654cb8bd011b877aa43270": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "c07c235314e9456f9a9c3550404b6cb5": {
+     "8fd7b6a17e804c90961d59398b635244": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a304343ad95c4cf888b0052e1ac42917": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c33ae892827943a9b19193d0fbbfa253",
+       "style": "IPY_MODEL_2325225341874e0b9cee528398d6424b",
+       "value": " 8/8 [00:09&lt;00:00,  1.37s/engine]"
+      }
+     },
+     "a88e9002f12849979a16528e113e9a54": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "HBoxModel",
       "state": {
        "children": [
-        "IPY_MODEL_91282c0c7de941548c6317b5ff049411",
-        "IPY_MODEL_77cc4198c58d471fa3a9d08fe5e2c16a",
-        "IPY_MODEL_118e6a646fe743748a5c2cb00649214a"
+        "IPY_MODEL_0421d9cb7f9b406d982ee0c005a9a532",
+        "IPY_MODEL_f10a317efcce44cd9ddd950a291e1076",
+        "IPY_MODEL_a304343ad95c4cf888b0052e1ac42917"
        ],
-       "layout": "IPY_MODEL_203a8e5c66bd40d19ef7abb4609a154b"
+       "layout": "IPY_MODEL_7ba86883f6654cb8bd011b877aa43270"
       }
      },
-     "d1fde61ad3b243238d78bee3544f58b0": {
+     "b3cd9eef2db342308a832c022cbb620d": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "d8594e6d653d45e5a85f865676c74765": {
+     "c33ae892827943a9b19193d0fbbfa253": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "de393bcdcc8c4715912601f723b0e302": {
+     "f10a317efcce44cd9ddd950a291e1076": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "FloatProgressModel",
       "state": {
        "bar_style": "success",
-       "layout": "IPY_MODEL_d1fde61ad3b243238d78bee3544f58b0",
-       "max": 256,
-       "style": "IPY_MODEL_932c41ad3e444c77b41ffc60e0ab6e60",
-       "value": 256
+       "layout": "IPY_MODEL_5109f916201e46279f135d7403112689",
+       "max": 8,
+       "style": "IPY_MODEL_6849ab149d6d41c99fe55794adfc8d23",
+       "value": 8
       }
-     },
-     "df8ccfffc9da43d7bd7e02d2222f770b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
      }
     },
     "version_major": 2,

--- a/docs/source/tutorial/intro.md
+++ b/docs/source/tutorial/intro.md
@@ -166,6 +166,14 @@ and connect to the already-running cluster with {meth}`.Cluster.from_file`
 cluster = ipp.Cluster.from_file()
 ```
 
+For a convenient one-liner to start a cluster and connect a client,
+use {meth}`~.Cluster.start_and_connect_sync`:
+
+```ipython
+In [1]: import ipyparallel as ipp
+In [2]: rc = ipp.Cluster(n=4).start_and_connect_sync()
+```
+
 More details about starting the IPython controller and engines can be found
 {ref}`here <parallel-process>`.
 


### PR DESCRIPTION
shorten the path to something useful, so it can be done in one line.

I was getting bothered by the tedious four-line quickstart repeated everywhere, which seemed too verbose:

```python
cluster = ipp.Cluster()
await cluster.start_cluster()
rc = cluster.connect_client()
rc.wait_for_engines()
```

so it's all bundled in one for the common case:


```python
client = ipp.Cluster(n=4).start_and_connect_sync()
```

plus `.start_cluster()` returns `self` so it can be chained, e.g.

```python
cluster = await ipp.Cluster(n=4).start_cluster()
```
