### PR TITLE
cancel wait_for_engines if we notice that an engine unregisters or crashes

### DIFF
--- a/ipyparallel/apps/baseapp.py
+++ b/ipyparallel/apps/baseapp.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 
+import traitlets
 from IPython.core.application import base_aliases as base_ip_aliases
 from IPython.core.application import base_flags as base_ip_flags
 from IPython.core.application import BaseIPythonApplication
@@ -22,6 +23,15 @@ from traitlets.config.application import catch_config_error
 from traitlets.config.application import LevelFormatter
 
 from .._version import __version__
+
+# FIXME: CUnicode is needed for cli parsing
+# with traitlets 4
+# bump when we require traitlets 5, which requires Python 3.7
+if int(traitlets.__version__.split(".", 1)[0]) < 5:
+    from traitlets import CUnicode
+else:
+    # don't need CUnicode with traitlets 4
+    CUnicode = Unicode
 
 # -----------------------------------------------------------------------------
 # Module errors
@@ -100,7 +110,7 @@ class BaseParallelApplication(BaseIPythonApplication):
         '', config=True, help="The ZMQ URL of the iplogger to aggregate logging."
     )
 
-    cluster_id = Unicode(
+    cluster_id = CUnicode(
         '',
         config=True,
         help="""String id to add to runtime files, to prevent name collisions when

--- a/ipyparallel/tests/_test_startup_crash.py
+++ b/ipyparallel/tests/_test_startup_crash.py
@@ -1,0 +1,6 @@
+import os
+import time
+
+
+time.sleep(int(os.environ.get("CRASH_DELAY") or "1"))
+os._exit(1)


### PR DESCRIPTION
hooks up to cluster if available, and also unregister events for engines that crash after registration