### PR TITLE
Fixes and test coverage for coalescing broadcast views

### DIFF
--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -833,6 +833,12 @@ class Client(HasTraits):
 
         if md['engine_uuid'] is not None:
             md['engine_id'] = self._engines.get(md['engine_uuid'], None)
+
+        if md['is_coalescing']:
+            # get destinations from target metadata
+            targets = msg_meta.get("broadcast_targets", [])
+            md['engine_uuid'], md['engine_id'] = map(list, zip(*targets))
+
         if 'date' in parent:
             md['submitted'] = parent['date']
         if 'started' in msg_meta:
@@ -917,9 +923,16 @@ class Client(HasTraits):
         md = self.metadata[msg_id]
         md.update(self._extract_metadata(msg))
 
-        e_outstanding = self._outstanding_dict[md['engine_uuid']]
-        if msg_id in e_outstanding:
-            e_outstanding.remove(msg_id)
+        if md['is_coalescing']:
+            engine_uuids = md['engine_uuid'] or []
+        else:
+            engine_uuids = [md['engine_uuid']]
+
+        for engine_uuid in engine_uuids:
+            if engine_uuid is not None:
+                e_outstanding = self._outstanding_dict[engine_uuid]
+                if msg_id in e_outstanding:
+                    e_outstanding.remove(msg_id)
 
         # construct result:
         if content['status'] == 'ok':
@@ -972,9 +985,16 @@ class Client(HasTraits):
         md = self.metadata[msg_id]
         md.update(self._extract_metadata(msg))
 
-        e_outstanding = self._outstanding_dict[md['engine_uuid']]
-        if msg_id in e_outstanding:
-            e_outstanding.remove(msg_id)
+        if md['is_coalescing']:
+            engine_uuids = md['engine_uuid'] or []
+        else:
+            engine_uuids = [md['engine_uuid']]
+
+        for engine_uuid in engine_uuids:
+            if engine_uuid is not None:
+                e_outstanding = self._outstanding_dict[engine_uuid]
+                if msg_id in e_outstanding:
+                    e_outstanding.remove(msg_id)
 
         # construct result:
         if content['status'] == 'ok':

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -896,7 +896,11 @@ class Client(HasTraits):
         """
 
         parent = msg['parent_header']
-        msg_id = parent['msg_id']
+        if self._should_use_metadata_msg_id(msg):
+            msg_id = msg['metadata']['original_msg_id']
+        else:
+            msg_id = parent['msg_id']
+
         future = self._futures.get(msg_id, None)
         if msg_id not in self.outstanding:
             if msg_id in self.history:

--- a/ipyparallel/controller/app.py
+++ b/ipyparallel/controller/app.py
@@ -974,6 +974,10 @@ class IPController(BaseParallelApplication):
         in_addr=None,
         out_addr=None,
     ):
+        if identity is not None:
+            logname = f"{scheduler_name}-{identity}"
+        else:
+            logname = scheduler_name
         return {
             'scheduler_class': scheduler_class,
             'in_addr': in_addr or self.client_url(scheduler_name),
@@ -984,7 +988,7 @@ class IPController(BaseParallelApplication):
             'identity': identity
             if identity is not None
             else bytes(scheduler_name, 'utf8'),
-            'logname': 'scheduler',
+            'logname': logname,
             'loglevel': self.log_level,
             'log_url': self.log_url,
             'config': dict(self.config),

--- a/ipyparallel/controller/task_scheduler.py
+++ b/ipyparallel/controller/task_scheduler.py
@@ -215,7 +215,7 @@ class TaskScheduler(Scheduler):
             registration_notification=self._register_engine,
             unregistration_notification=self._unregister_engine,
         )
-        self.log.info("Scheduler started [%s]" % self.scheme_name)
+        self.log.info("Task scheduler started [%s]" % self.scheme_name)
         self.notifier_stream.on_recv(self.dispatch_notification)
 
     # -----------------------------------------------------------------------

--- a/ipyparallel/tests/test_view_broadcast.py
+++ b/ipyparallel/tests/test_view_broadcast.py
@@ -9,6 +9,8 @@ needs_map = pytest.mark.xfail(reason="map not yet implemented")
 
 @pytest.mark.usefixtures('ipython')
 class TestBroadcastView(test_view.TestView):
+    is_coalescing = False
+
     def setUp(self):
         super().setUp()
         self._broadcast_view_used = False
@@ -20,7 +22,9 @@ class TestBroadcastView(test_view.TestView):
                 return real_direct_view(targets)
             else:
                 self._broadcast_view_used = True
-                return self.client.broadcast_view(targets)
+                return self.client.broadcast_view(
+                    targets, is_coalescing=self.is_coalescing
+                )
 
         self.client.direct_view = broadcast_or_direct
 
@@ -57,3 +61,7 @@ class TestBroadcastView(test_view.TestView):
     @pytest.mark.xfail(reason="Tracking gets disconnected from original message")
     def test_scatter_tracked(self):
         pass
+
+
+class TestBroadcastViewCoalescing(TestBroadcastView):
+    is_coalescing = True

--- a/ipyparallel/tests/test_view_broadcast.py
+++ b/ipyparallel/tests/test_view_broadcast.py
@@ -15,7 +15,7 @@ class TestBroadcastView(test_view.TestView):
         super().setUp()
         self._broadcast_view_used = False
         # use broadcast view for direct API
-        real_direct_view = self.client.direct_view
+        real_direct_view = self.client.real_direct_view = self.client.direct_view
 
         def broadcast_or_direct(targets):
             if isinstance(targets, int):
@@ -65,3 +65,54 @@ class TestBroadcastView(test_view.TestView):
 
 class TestBroadcastViewCoalescing(TestBroadcastView):
     is_coalescing = True
+
+    @pytest.mark.xfail(reason="coalescing view doesn't preserve target order")
+    def test_target_ordering(self):
+        self.minimum_engines(4)
+        ids_in_order = self.client.ids
+        dv = self.client.real_direct_view(ids_in_order)
+
+        dv.scatter('rank', ids_in_order, flatten=True, block=True)
+        assert dv['rank'] == ids_in_order
+
+        view = self.client.broadcast_view(ids_in_order, is_coalescing=True)
+        assert view['rank'] == ids_in_order
+
+        view = self.client.broadcast_view(ids_in_order[::-1], is_coalescing=True)
+        assert view['rank'] == ids_in_order[::-1]
+
+        view = self.client.broadcast_view(ids_in_order[::2], is_coalescing=True)
+        assert view['rank'] == ids_in_order[::2]
+
+        view = self.client.broadcast_view(ids_in_order[::-2], is_coalescing=True)
+        assert view['rank'] == ids_in_order[::-2]
+
+    def test_engine_metadata(self):
+        self.minimum_engines(4)
+        ids_in_order = sorted(self.client.ids)
+        dv = self.client.real_direct_view(ids_in_order)
+        dv.scatter('rank', ids_in_order, flatten=True, block=True)
+        view = self.client.broadcast_view(ids_in_order, is_coalescing=True)
+        ar = view.pull('rank', block=False)
+        result = ar.get(timeout=10)
+        assert isinstance(ar.engine_id, list)
+        assert isinstance(ar.engine_uuid, list)
+        assert result == ar.engine_id
+        assert sorted(ar.engine_id) == ids_in_order
+
+        even_ids = ids_in_order[::-2]
+        view = self.client.broadcast_view(even_ids, is_coalescing=True)
+        ar = view.pull('rank', block=False)
+        result = ar.get(timeout=10)
+        assert isinstance(ar.engine_id, list)
+        assert isinstance(ar.engine_uuid, list)
+        assert result == ar.engine_id
+        assert sorted(ar.engine_id) == sorted(even_ids)
+
+    @pytest.mark.xfail(reason="displaypub ordering not preserved")
+    def test_apply_displaypub(self):
+        pass
+
+
+# FIXME
+del TestBroadcastView

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -427,7 +427,7 @@ def local_logger(logname, loglevel=logging.DEBUG):
     handler = logging.StreamHandler()
     handler.setLevel(loglevel)
     formatter = logging.Formatter(
-        "%(asctime)s.%(msecs).03d [%(levelname)1.1s %(name)s] %(message)s",
+        "%(asctime)s.%(msecs).03d [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     handler.setFormatter(formatter)


### PR DESCRIPTION
avoids error: got unknown result: 098dcdc9-326e56d369825c8d5c63034e_3911_1_3a745ca5-2189263bff5e0e0520d62493 with execute (including `%px`) when using a coalescing broadcast view.

and make sure we have test coverage for `BroadcastView(is_coalescing=True)`