### PR TITLE
set HWM=0 more thoroughly

### DIFF
--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -783,6 +783,7 @@ class Client(HasTraits):
             connect_socket(self._broadcast_socket, cfg['broadcast'])
 
             self._notification_socket = self._context.socket(zmq.SUB)
+            self._notification_socket.RCVHWM = 0
             self._notification_socket.setsockopt(zmq.SUBSCRIBE, b'')
             connect_socket(self._notification_socket, cfg['notification'])
 
@@ -790,6 +791,7 @@ class Client(HasTraits):
             connect_socket(self._control_socket, cfg['control'])
 
             self._iopub_socket = self._context.socket(zmq.SUB)
+            self._iopub_socket.RCVHWM = 0
             self._iopub_socket.setsockopt(zmq.SUBSCRIBE, b'')
             connect_socket(self._iopub_socket, cfg['iopub'])
 

--- a/ipyparallel/engine/app.py
+++ b/ipyparallel/engine/app.py
@@ -623,6 +623,7 @@ class IPEngine(BaseParallelApplication):
             # create iopub stream:
             iopub_addr = url('iopub')
             iopub_socket = ctx.socket(zmq.PUB)
+            iopub_socket.SNDHWM = 0
             iopub_socket.setsockopt(zmq.IDENTITY, identity)
             connect(iopub_socket, iopub_addr)
             try:


### PR DESCRIPTION
- set on engine and client sockets
- fix direction on iopub scheduler (in is engine-facing, out is client-facing)

this fixes an issue where `wait_for_outputs` could hang indefinitely with a large number (and size) of iopub messages due to dropped messages