### PR TITLE
Fixes for loading cluster from files

### DIFF
--- a/ipyparallel/cluster/app.py
+++ b/ipyparallel/cluster/app.py
@@ -216,8 +216,16 @@ class IPClusterList(BaseParallelApplication):
     )
 
     def start(self):
+        profile_dirs = None
+        if (
+            self.profile != "default"
+            or "ProfileDir" in self.config
+            and "location" in self.config.ProfileDir
+        ):
+            # profile-directory specified, only consider
+            profile_dirs = [self.profile_dir.location]
         cluster_manager = ClusterManager(parent=self)
-        clusters = cluster_manager.load_clusters()
+        clusters = cluster_manager.load_clusters(profile_dirs=profile_dirs)
         if self.output_format == "text":
             # TODO: measure needed profile/cluster id width
             print(

--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -117,6 +117,13 @@ class Cluster(AsyncFirst, LoggingConfigurable):
     def _default_profile_dir(self):
         return _default_profile_dir(profile=self.profile)
 
+    @validate("profile_dir")
+    def _validate_profile_dir(self, proposal):
+        path = proposal.value
+        if path:
+            return os.path.abspath(path)
+        return path
+
     profile = Unicode(
         "",
         help="""The profile name,

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -1118,6 +1118,13 @@ class SSHLauncher(LocalProcessLauncher):
         if 'pid' in d and d['pid'] > 0:
             self._start_waiting()
 
+    def poll(self):
+        """Override poll"""
+        if self.state == 'running':
+            return None
+        else:
+            return 0
+
     def get_output(self, remove=False):
         """Retrieve engine output from the remote file"""
         if self._output is None:

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -1056,12 +1056,16 @@ class SSHLauncher(LocalProcessLauncher):
 
     @default("remote_output_file")
     def _default_remote_output_file(self):
-        if 'engine' in ' '.join(self.program):
+        full_program = ' '.join(self.program)
+        if 'engine' in full_program:
             name = 'ipengine'
+        elif 'controller' in full_program:
+            name = 'ipcontroller'
         else:
             name = self.program[0]
         return os.path.join(
             self.remote_profile_dir,
+            'log',
             os.path.basename(name) + f"-{time.time():.4f}.out",
         )
 

--- a/ipyparallel/tests/test_cluster.py
+++ b/ipyparallel/tests/test_cluster.py
@@ -4,6 +4,7 @@ import logging
 import os
 import signal
 import sys
+import tempfile
 import time
 from pathlib import Path
 from unittest import mock
@@ -233,25 +234,27 @@ def test_cluster_abbreviations(classname, expected_class):
 
 
 async def test_cluster_repr(Cluster):
-    c = Cluster(cluster_id="test", profile_dir='/tmp')
-    assert repr(c) == "<Cluster(cluster_id='test', profile_dir='/tmp')>"
+    tmp = tempfile.gettempdir()
+    c = Cluster(cluster_id="test", profile_dir=tmp)
+    assert repr(c) == f"<Cluster(cluster_id='test', profile_dir={repr(tmp)})>"
     await c.start_controller()
     assert (
         repr(c)
-        == "<Cluster(cluster_id='test', profile_dir='/tmp', controller=<running>)>"
+        == f"<Cluster(cluster_id='test', profile_dir={repr(tmp)}, controller=<running>)>"
     )
     await c.start_engines(1, 'engineid')
     assert (
         repr(c)
-        == "<Cluster(cluster_id='test', profile_dir='/tmp', controller=<running>, engine_sets=['engineid'])>"
+        == f"<Cluster(cluster_id='test', profile_dir={repr(tmp)}, controller=<running>, engine_sets=['engineid'])>"
     )
 
 
 async def test_cluster_manager():
     m = cluster.ClusterManager()
     assert m.clusters == {}
-    key, c = m.new_cluster(profile_dir="/tmp")
-    assert c.profile_dir == "/tmp"
+    tmp = tempfile.gettempdir()
+    key, c = m.new_cluster(profile_dir=tmp)
+    assert c.profile_dir == tmp
     assert m.get_cluster(key) is c
     with pytest.raises(KeyError):
         m.get_cluster("nosuchcluster")


### PR DESCRIPTION
Some issues I encountered while testing #598 

- SSHLauncher.poll is called when waiting for connection files,
  but the inherited method doesn't make sense
- ensure Cluster.profile_dir is an absolute path (otherwise saved paths may be evaluated relative to incorrect locations)
- more consistent output locations for ssh
- ipcluster list only looks in specified profile, if it is specified