### PR TITLE
set output_file on batch launchers

### DIFF
--- a/ipyparallel/tests/test_cluster.py
+++ b/ipyparallel/tests/test_cluster.py
@@ -172,6 +172,19 @@ async def test_restart_engines(Cluster, engine_launcher_class):
         assert set(after_pids).intersection(before_pids) == set()
 
 
+async def test_get_output(Cluster, engine_launcher_class):
+    n = 2
+    async with Cluster(engine_launcher_class=engine_launcher_class, n=n) as rc:
+        cluster = rc.cluster
+        engine_set_id = next(iter(cluster.engines))
+        engine_set = cluster.engines[engine_set_id]
+    out = engine_set.get_output()
+    print(f"---engine output---\n{out}\n---end engine output---")
+    assert out
+    assert 'Completed registration with id 0' in out
+    assert 'Completed registration with id 1' in out
+
+
 async def test_async_with(Cluster):
     async with Cluster(n=5) as rc:
         assert sorted(rc.ids) == list(range(5))

--- a/ipyparallel/tests/test_mpi.py
+++ b/ipyparallel/tests/test_mpi.py
@@ -2,6 +2,7 @@ import shutil
 
 import pytest
 
+from .test_cluster import test_get_output  # noqa: F401
 from .test_cluster import test_restart_engines  # noqa: F401
 from .test_cluster import test_signal_engines  # noqa: F401
 from .test_cluster import test_start_stop_cluster  # noqa: F401

--- a/ipyparallel/tests/test_slurm.py
+++ b/ipyparallel/tests/test_slurm.py
@@ -2,6 +2,7 @@ import shutil
 
 import pytest
 
+from .test_cluster import test_get_output  # noqa: F401
 from .test_cluster import test_restart_engines  # noqa: F401
 from .test_cluster import test_signal_engines  # noqa: F401
 from .test_cluster import test_start_stop_cluster  # noqa: F401

--- a/ipyparallel/tests/test_ssh.py
+++ b/ipyparallel/tests/test_ssh.py
@@ -4,6 +4,7 @@ import pytest
 from traitlets.config import Config
 
 from .conftest import Cluster as BaseCluster  # noqa: F401
+from .test_cluster import test_get_output  # noqa: F401
 from .test_cluster import test_restart_engines  # noqa: F401
 from .test_cluster import test_signal_engines  # noqa: F401
 from .test_cluster import test_start_stop_cluster  # noqa: F401


### PR DESCRIPTION
so output goes to the log directory, and can be retrieved with `get_output()` for error reporting.

Need to add a test to verify this for slurm

It's a different regex for every launcher, so it would be really good to get other batch systems tested, but we only have SLURM set up for now, which is the most-used, I think.

closes #525