### PR TITLE
CI: run slurm in docker-compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
             cluster_type: mpi
           - python: "3.7"
             cluster_type: slurm
+            container: slurmctld
           - python: "3.6"
             tornado: "5.1.1"
           - python: "3.7"
@@ -84,14 +85,10 @@ jobs:
       - name: Set up slurm
         if: ${{ matrix.cluster_type == 'slurm' }}
         run: |
-          sudo rm -rf /var/lib/apt/lists
-          sudo apt-get update && sudo apt-get -f -y install && sudo apt-get -y install slurm-wlm
-          sudo cp ci/slurm/slurm.conf /etc/slurm-llnl/
-          sudo mkdir /var/spool/slurmctl
-          sudo mkdir /var/spool/slurmd
-          sudo service munge start
-          sudo service slurmd start
-          sudo service slurmctld start
+          export DOCKER_BUILDKIT=1
+          export COMPOSE_DOCKER_CLI_BUILD=1
+          cd ci/slurm
+          docker-compose up -d --build
 
       - name: Install Python (conda) ${{ matrix.python }}
         if: ${{ matrix.cluster_type == 'mpi' }}
@@ -124,10 +121,14 @@ jobs:
       - name: Show environment
         run: pip freeze
 
+      - name: Run tests in container ${{ matrix.container }}
+        if: ${{ matrix.container }}
+        run: echo "EXEC=docker exec -i ${{ matrix.container }}" >> $GITHUB_ENV
+
       - name: Run ${{ matrix.cluster_type }} tests
         if: ${{ matrix.cluster_type }}
         run: |
-          pytest -ra -v --maxfail=2 --color=yes --cov=ipyparallel ipyparallel/tests/test_${{ matrix.cluster_type }}.py
+          ${EXEC:-} pytest -ra -v --maxfail=2 --color=yes --cov=ipyparallel ipyparallel/tests/test_${{ matrix.cluster_type }}.py
 
       - name: Run tests
         if: ${{ ! matrix.cluster_type }}
@@ -135,6 +136,12 @@ jobs:
         #        https://github.com/actions/runner/issues/241
         run: |
           pytest -ra -v --maxfail=3 --color=yes --cov=ipyparallel ipyparallel/tests
+
+      - name: Fixup coverage permissions ${{ matrix.container }}
+        if: ${{ matrix.container }}
+        run: |
+          ls -l .coverage*
+          ${EXEC} chmod -R a+rw .coverage*
 
       - name: Submit codecov report
         run: |
@@ -144,9 +151,9 @@ jobs:
         if: ${{ matrix.cluster_type == 'slurm' && failure() }}
         run: |
           set -x
-          slurmd -C
-          ls -l
-          squeue
-          sinfo
-          scontrol show node=localhost
-          sudo cat /var/log/slurm-llnl/*
+          docker ps -a
+          docker logs slurmctld
+          docker exec -i slurmctld squeue --states=all
+          docker exec -i slurmctld sinfo
+          docker logs c1
+          docker logs c2

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -1,0 +1,20 @@
+# syntax = docker/dockerfile:1.2.1
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN --mount=type=cache,target=/var/cache/apt \
+ rm -f /etc/apt/apt.conf.d/docker-clean \
+ && apt-get update && apt-get -y install python3-pip slurm-wlm
+ENV PIP_CACHE_DIR=/tmp/pip-cache
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} python3 -m pip install ipyparallel pytest-asyncio pytest-cov pytest-tornado
+RUN mkdir /var/spool/slurmctl \
+ && mkdir /var/spool/slurmd
+COPY slurm.conf /etc/slurm-llnl/slurm.conf
+COPY entrypoint.sh /entrypoint
+ENV IPP_DISABLE_JS=1
+ENTRYPOINT ["/entrypoint"]
+
+# the mounted directory
+RUN mkdir /io
+ENV PYTHONPATH=/io
+WORKDIR "/io"

--- a/ci/slurm/docker-compose.yaml
+++ b/ci/slurm/docker-compose.yaml
@@ -1,0 +1,84 @@
+version: "2.2"
+
+services:
+  slurmctld:
+    image: ipp-cluster:slurm
+    build: .
+    container_name: slurmctld
+    hostname: slurmctld
+    command:
+      - tail
+      - "-f"
+      - /var/log/slurm-llnl/slurmctld.log
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - slurm_jobdir:/data
+      - var_log_slurm:/var/log/slurm
+      - ../..:/io
+    expose:
+      - "6817"
+    networks:
+      common-network:
+        ipv4_address: 10.1.1.10
+
+  c1:
+    image: ipp-cluster:slurm
+    build: .
+    hostname: c1
+    command:
+      - tail
+      - "-f"
+      - /var/log/slurm-llnl/slurmd.log
+    container_name: c1
+
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - slurm_jobdir:/data
+      - var_log_slurm:/var/log/slurm
+      - ../..:/io
+    expose:
+      - "6818"
+    depends_on:
+      - "slurmctld"
+    networks:
+      common-network:
+        ipv4_address: 10.1.1.11
+
+  c2:
+    image: ipp-cluster:slurm
+    build: .
+    command:
+      - tail
+      - "-f"
+      - /var/log/slurm-llnl/slurmd.log
+    hostname: c2
+    container_name: c2
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - slurm_jobdir:/data
+      - var_log_slurm:/var/log/slurm
+      - ../..:/io
+    expose:
+      - "6818"
+    depends_on:
+      - "slurmctld"
+    networks:
+      common-network:
+        ipv4_address: 10.1.1.12
+
+volumes:
+  etc_munge:
+  etc_slurm:
+  slurm_jobdir:
+  var_log_slurm:
+
+networks:
+  common-network:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.1.1.0/24

--- a/ci/slurm/entrypoint.sh
+++ b/ci/slurm/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -ex
+# set permissions on munge dir, may be mounted
+chown -R munge:munge /etc/munge
+
+echo "starting munge"
+service munge start
+
+echo "hostname=$(hostname)"
+if [[ "$(hostname)" == *"slurmctl"* ]]; then
+    echo "starting slurmctld"
+    service slurmctld start
+else
+    echo "starting slurmd"
+    service slurmd start
+fi
+
+exec "$@"

--- a/ci/slurm/slurm.conf
+++ b/ci/slurm/slurm.conf
@@ -2,7 +2,7 @@
 # Put this file on all nodes of your cluster.
 # See the slurm.conf man page for more information.
 #
-SlurmctldHost=localhost
+SlurmctldHost=slurmctld
 #
 #MailProg=/bin/mail
 MpiDefault=none
@@ -49,5 +49,11 @@ SlurmdLogFile=/var/log/slurm-llnl/slurmd.log
 # COMPUTE NODES
 # Note: CPUs apparently cannot be oversubscribed
 # this can only run where at least 2 CPUs are available
-NodeName=localhost NodeHostName=localhost NodeAddr=127.0.0.1 CPUs=2 State=UNKNOWN
-PartitionName=part Nodes=localhost Default=YES MaxTime=INFINITE State=UP OverSubscribe=YES
+#NodeName=localhost NodeHostName=localhost NodeAddr=127.0.0.1 CPUs=2 State=UNKNOWN
+#PartitionName=part Nodes=localhost Default=YES MaxTime=INFINITE State=UP OverSubscribe=YES
+
+# COMPUTE NODES
+NodeName=c[1-2] RealMemory=4096 CPUs=2 State=UNKNOWN
+#
+# PARTITIONS
+PartitionName=normal Default=yes Nodes=c[1-2] Priority=50 DefMemPerCPU=2048 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP

--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -596,7 +596,10 @@ class Cluster(AsyncFirst, LoggingConfigurable):
                 )
 
         else:
+            # copy to make sure change events fire
+            controller_args = list(controller_args)
             add_args = controller_args.extend
+
         if self.controller_ip:
             add_args(['--ip=%s' % self.controller_ip])
         if self.controller_location:

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -1988,6 +1988,13 @@ class BatchSystemLauncher(BaseLauncher):
     def get_output(self, remove=True):
         return LocalProcessLauncher.get_output(self, remove=remove)
 
+    def poll(self):
+        """Poll not implemented
+
+        Need to use `squeue` and friends to check job status
+        """
+        return None
+
 
 class BatchControllerLauncher(BatchSystemLauncher, ControllerLauncher):
     @default("program")

--- a/ipyparallel/tests/test_slurm.py
+++ b/ipyparallel/tests/test_slurm.py
@@ -1,18 +1,42 @@
 import shutil
 
 import pytest
+from traitlets.config import Config
 
+from .conftest import temporary_ipython_dir
 from .test_cluster import test_get_output  # noqa: F401
 from .test_cluster import test_restart_engines  # noqa: F401
 from .test_cluster import test_signal_engines  # noqa: F401
 from .test_cluster import test_start_stop_cluster  # noqa: F401
 from .test_cluster import test_to_from_dict  # noqa: F401
 
-# import tests that use engine_launcher_class fixture
 
-# override engine_launcher_class
+# put ipython dir on shared filesystem
+@pytest.fixture(autouse=True, scope="module")
+def ipython_dir(request):
+    if shutil.which("sbatch") is None:
+        pytest.skip("Requires slurm")
+    with temporary_ipython_dir(prefix="/data/") as ipython_dir:
+        yield ipython_dir
+
+
+@pytest.fixture
+def cluster_config():
+    c = Config()
+    c.Cluster.controller_ip = '0.0.0.0'
+    return c
+
+
+# override launcher classes
 @pytest.fixture
 def engine_launcher_class():
     if shutil.which("sbatch") is None:
         pytest.skip("Requires slurm")
-    return 'Slurm'
+    return 'slurm'
+
+
+@pytest.fixture
+def controller_launcher_class():
+    if shutil.which("sbatch") is None:
+        pytest.skip("Requires slurm")
+    return 'slurm'


### PR DESCRIPTION
allows more than N=2, which is required to run a controller and two engines

adapted and simplified from dask-jobqueue

test coverage for SlurmControllerLauncher