### PR TITLE
make sure MPIControllerLauncher is tested

### DIFF
--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -864,7 +864,7 @@ class MPILauncher(LocalProcessLauncher):
             + self.program_args
         )
 
-    def start(self, n):
+    def start(self, n=1):
         """Start n instances of the program using mpiexec."""
         self.n = n
         return super(MPILauncher, self).start()

--- a/ipyparallel/tests/test_mpi.py
+++ b/ipyparallel/tests/test_mpi.py
@@ -15,4 +15,11 @@ from .test_cluster import test_to_from_dict  # noqa: F401
 def engine_launcher_class():
     if shutil.which("mpiexec") is None:
         pytest.skip("Requires mpiexec")
-    return 'MPI'
+    return 'mpi'
+
+
+@pytest.fixture
+def controller_launcher_class():
+    if shutil.which("mpiexec") is None:
+        pytest.skip("Requires mpiexec")
+    return 'mpi'


### PR DESCRIPTION
and fix required `n` argument to start