### PR TITLE
changelog for 8.0

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,7 +4,11 @@
 
 Changes in IPython Parallel
 
-## 7.2
+## 8.0
+
+This is marked as a major revision because of the change to pass connection information via environment variables.
+BatchSystem launchers with a custom template will need to make sure to set flags that inherit environment variables,
+such as `#PBS -V` or `#SBATCH --export=ALL`.
 
 New:
 

--- a/docs/source/reference/mpi.md
+++ b/docs/source/reference/mpi.md
@@ -68,10 +68,10 @@ Just like `mpi`, you can specify these as the controller
 cluster = ipp.Cluster(engines="slurm", controller="slurm")
 ```
 
-:::{versionadded} 7.2
+:::{versionadded} 8.0
 
-The `controller` and `engines` arguments are new in IPython Parallel 7.2.
-In 7.0-7.1, these arguments had to be called `controller_launcher_class`
+The `controller` and `engines` arguments are new in IPython Parallel 8.0.
+In 7.x, these arguments had to be called `controller_launcher_class`
 and `engine_launcher_class`, respectively.
 :::
 

--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -331,7 +331,7 @@ class AsyncResult(Future):
             When return_when=FIRST_EXCEPTION, will raise immediately on the first exception,
             rather than waiting for all results to finish before reporting errors.
 
-        .. versionchanged:: 7.2
+        .. versionchanged:: 8.0
             Added `return_when` argument.
         """
         if return_when == FIRST_COMPLETED:
@@ -410,7 +410,7 @@ class AsyncResult(Future):
         Inverse of .split(),
         used for rejoining split results in wait.
 
-        .. versionadded: 7.2
+        .. versionadded:: 8.0
         """
         if not async_results:
             raise ValueError("Must specify at least one AsyncResult to join")
@@ -437,7 +437,7 @@ class AsyncResult(Future):
         This can be passed to `concurrent.futures.wait` and friends
         to get partial results.
 
-        .. versionadded: 7.2
+        .. versionadded:: 8.0
         """
         if len(self._children) == 1:
             # nothing to do if we're already representing a single message
@@ -486,7 +486,7 @@ class AsyncResult(Future):
                 representing the completed and still-pending subsets of results,
                 matching the return value of `wait` itself.
 
-        .. versionchanged:: 7.2
+        .. versionchanged:: 8.0
             Added `return_when`.
         """
         if timeout and timeout < 0:

--- a/ipyparallel/client/view.py
+++ b/ipyparallel/client/view.py
@@ -1038,7 +1038,7 @@ class LazyMapIterator:
 
     Has a `.cancel()` method to stop consuming new inputs.
 
-    .. versionadded:: 7.2
+    .. versionadded:: 8.0
     """
 
     def __init__(self, gen, signal_done):

--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -80,7 +80,7 @@ class Cluster(AsyncFirst, LoggingConfigurable):
     All async methods can be called synchronously with a `_sync` suffix,
     e.g. `cluster.start_cluster_sync()`
 
-    .. versionchanged:: 7.2
+    .. versionchanged:: 8.0
         controller and engine launcher classes can be specified via
         `Cluster(controller='ssh', engines='mpi')`
         without the `_launcher_class` suffix.
@@ -169,7 +169,7 @@ class Cluster(AsyncFirst, LoggingConfigurable):
         take a long time in a job queue,
         and the engines should enter the queue before the controller is running.
 
-        .. versionadded: 7.2
+        .. versionadded:: 8.0
         """,
     )
 
@@ -298,7 +298,7 @@ class Cluster(AsyncFirst, LoggingConfigurable):
         which is tedious to get to via the `engines` dict
         with random engine set ids.
 
-        ..versionadded: 7.2
+        ..versionadded:: 8.0
         """
         if self.engines:
             return next(iter(self.engines.values()))

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -216,7 +216,7 @@ class BaseLauncher(LoggingConfigurable):
     environment = Dict(
         help="""Set environment variables for the launched process
 
-        .. versionadded: 7.2
+        .. versionadded:: 8.0
         """,
         config=True,
     )


### PR DESCRIPTION
Not 100% sure whether this should be 7.2 or 8.0

The most *likely* breaking change is the env switch in Launchers. *Some* custom batch templates that do not export variables (`$PBS -V`) will stop working. But only if they *also* use `{program_and_args}` instead of `--profile-dir={profile_dir} --cluster-id={cluster_id}` which continue to work.