### PR TITLE
adopt tbump for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,13 @@ jobs:
           jupyter labextension list 2>&1 | grep ipyparallel
           jupyter server extension list 2>&1 | grep ipyparallel
 
+      # ref: https://github.com/actions/upload-artifact#readme
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ipyparallel-${{ github.sha }}
+          path: "dist/*"
+          if-no-files-found: error
+
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
         env:

--- a/ipyparallel/_version.py
+++ b/ipyparallel/_version.py
@@ -1,2 +1,34 @@
-version_info = (8, 0, 0, "b1")
-__version__ = ".".join(map(str, version_info))
+import re
+
+__version__ = "8.0.0b1"
+
+# matches tbump regex in pyproject.toml
+_version_regex = re.compile(
+    r'''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (?P<pre>((a|b|rc)\d+))?
+  (\.
+    (?P<dev>dev\d*)
+  )?
+  ''',
+    re.VERBOSE,
+)
+
+_version_fields = _version_regex.match(__version__).groupdict()
+version_info = tuple(
+    field
+    for field in (
+        int(_version_fields["major"]),
+        int(_version_fields["minor"]),
+        int(_version_fields["patch"]),
+        _version_fields["pre"],
+        _version_fields["dev"],
+    )
+    if field is not None
+)
+
+__all__ = ["__version__", "version_info"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipyparallel-labextension",
-  "version": "8.0.0",
+  "version": "8.0.0b1",
   "private": true,
   "description": "A JupyterLab extension for IPython Parallel.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,39 @@ target_version = [
     "py37",
     "py38",
 ]
+
+[tool.tbump]
+# Uncomment this if your project is hosted on GitHub:
+github_url = "https://github.com/jupyterhub/jupyterhub"
+
+[tool.tbump.version]
+current = "8.0.0b1"
+
+# pep440 regex
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (?P<pre>((a|b|rc)\d+))?
+  (\.
+    (?P<dev>dev\d*)
+  )?
+  '''
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "{new_version}"
+
+# For each file to patch, add a [[tool.tbump.file]] config
+# section containing the path of the file, relative to the
+# pyproject.toml location.
+
+[[tool.tbump.file]]
+src = "ipyparallel/_version.py"
+search = '__version__ = "{current_version}"'
+
+[[tool.tbump.file]]
+src = "package.json"
+search = '"version": "{current_version}"'


### PR DESCRIPTION
keeps versions in sync in multiple files (package.json, _version.py)

For simplicity, generates version_info from `__version__` instead of the other way around, because tbump doesn't support generating version_info very well. It's more complicated this way, but should never need to change.