### PR TITLE
flaky imap_infinite

### DIFF
--- a/ipyparallel/tests/test_lbview.py
+++ b/ipyparallel/tests/test_lbview.py
@@ -169,7 +169,7 @@ class TestLoadBalancedView(ClusterTestCase):
         # wait
         self.client.wait(timeout=self.timeout)
         # verify that max_outstanding wasn't exceeded
-        assert 5 <= len(self.view.history) < 10
+        assert 4 <= len(self.view.history) < 10
 
     def test_imap_unordered(self):
         self.minimum_engines(4)


### PR DESCRIPTION
windows can be super slow, and not consume task 5 before we start waiting