### PR TITLE
add Cluster.start_and_connect(activate=True)

### DIFF
--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1455,7 +1455,7 @@ class Client(HasTraits):
         return futures
 
     def wait_for_engines(
-        self, n, *, timeout=-1, block=True, interactive=None, widget=None
+        self, n=None, *, timeout=-1, block=True, interactive=None, widget=None
     ):
         """Wait for `n` engines to become available.
 
@@ -1490,6 +1490,18 @@ class Client(HasTraits):
         ------
         TimeoutError : if timeout is reached.
         """
+        if n is None:
+            # get n from cluster, if not specified
+            if self.cluster is None:
+                raise TypeError("n engines to wait for must be specified")
+
+            if self.cluster.n:
+                n = self.cluster.n
+            else:
+                # compute n from engine sets,
+                # e.g. the default where n is calculated at runtime from `cpu_count()`
+                n = sum(engine_set.n for engine_set in self.cluster.engines.values())
+
         if len(self.ids) >= n:
             if block:
                 return

--- a/ipyparallel/tests/test_cluster.py
+++ b/ipyparallel/tests/test_cluster.py
@@ -359,3 +359,17 @@ async def test_wait_for_engines_crash(Cluster):
         rc = c.connect_client_sync()
         with pytest.raises(ipp.error.EngineError):
             rc.wait_for_engines(3, timeout=20)
+
+
+@pytest.mark.parametrize("activate", (True, False))
+def test_start_and_connect_activate(ipython, Cluster, activate):
+    rc = Cluster(n=2, log_level=10).start_and_connect_sync(activate=activate)
+    with rc:
+        if activate:
+            assert "px" in ipython.magics_manager.magics["cell"]
+            px = ipython.magics_manager.magics["cell"]["px"]
+            assert px.__self__.view.client is rc
+        else:
+            if "px" in ipython.magics_manager.magics["cell"]:
+                px = ipython.magics_manager.magics["cell"]["px"]
+                assert px.__self__.view.client is not rc


### PR DESCRIPTION
creates a blocking DirectView on all engines, registering `%px` magics and friends

One-liner to start a cluster and register it for interactive use:

```python
rc = Cluster(engines="mpi", n=8).start_and_connect(activate=True)

%px os.getpid()
```

`wait_for_engines` can also derive default `n` from parent cluster, if available, rather than requiring it to be specified.