### PR TITLE
Load profile config by default

### DIFF
--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -368,6 +368,13 @@ class Cluster(AsyncFirst, LoggingConfigurable):
         config.merge(direct_config)
         return config
 
+    @default("config")
+    def _default_config(self):
+        if self.load_profile:
+            return self.profile_config
+        else:
+            return Config()
+
     def __init__(self, *, engines=None, controller=None, **kwargs):
         """Construct a Cluster"""
         # handle more intuitive aliases, which match ipcluster cli args, etc.


### PR DESCRIPTION
if nothing tried to set the config, profile_config wasn't loaded

profile_config was only loaded in the validator, which only takes effect if something tries to set the value (i.e. default is unused)

Reported in https://github.com/ipython/ipyparallel/issues/639#issuecomment-984666690