### PR TITLE
Start RetroLab support

### DIFF
--- a/.binder/jupyter_config.json
+++ b/.binder/jupyter_config.json
@@ -1,0 +1,5 @@
+{
+  "LabApp": {
+    "collaborative": true
+  }
+}

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+jlpm --prefer-offline --ignore-optional --ignore-scripts
+
+jlpm build
+
+IPP_DISABLE_JS=1 python -m pip install -e .[test,benchmark]
+
+jupyter serverextension enable --sys-prefix --py ipyparallel
+jupyter serverextension list
+
+jupyter server extension enable --sys-prefix --py ipyparallel
+jupyter server extension list
+
+jupyter nbextension install --symlink --sys-prefix --py ipyparallel
+jupyter nbextension enable --sys-prefix --py ipyparallel
+jupyter nbextension list
+
+jlpm install:extension
+jupyter labextension list

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,14 +1,14 @@
-# apps
-jupyterlab >=3.2.4
-retrolab >=0.3.13
-
-# `collaborative` is on
-jupyterlab-link-share
 
 # depfinder results for /examples/
 ipywidgets
+# apps
+jupyterlab >=3.2.4
+
+# `collaborative` is on
+jupyterlab-link-share
 matplotlib
 networkx
 pidigits
 requests
+retrolab >=0.3.13
 wordfreq

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,0 +1,14 @@
+# apps
+jupyterlab >=3.2.4
+retrolab >=0.3.13
+
+# `collaborative` is on
+jupyterlab-link-share
+
+# depfinder results for /examples/
+ipywidgets
+matplotlib
+networkx
+pidigits
+requests
+wordfreq

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,10 +1,5 @@
-
-# depfinder results for /examples/
 ipywidgets
-# apps
 jupyterlab >=3.2.4
-
-# `collaborative` is on
 jupyterlab-link-share
 matplotlib
 networkx

--- a/ci/ssh/Dockerfile
+++ b/ci/ssh/Dockerfile
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 ENV MAMBA_ROOT_PREFIX=/opt/conda
 ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
+ENV IPP_DISABLE_JS=1
 RUN wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba \
  && mv bin/micromamba /usr/local/bin/micromamba
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,6 +11,6 @@ dependencies:
   - nbsphinx
   - myst-parser
 
-  - matplotlib
+  - matplotlib-base
   # nodejs needed for extension build
   - nodejs

--- a/lab/style/index.css
+++ b/lab/style/index.css
@@ -17,10 +17,6 @@
  * Rules related to the cluster manager.
  */
 
-.ipp-ClusterManager {
-  border-top: 6px solid var(--jp-toolbar-border-color);
-}
-
 .ipp-ClusterManager .jp-Toolbar {
   align-items: center;
 }

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ from setupbase import wrap_installers, npm_builder, get_data_files
 
 data_files = get_data_files(data_files_spec)
 
-builder = npm_builder(build_cmd="build:prod")
+builder = npm_builder(build_cmd="build:prod", npm="jlpm")
 if os.environ.get("IPP_DISABLE_JS") == "1":
     print("Skipping js installation")
     cmdclass = {}
@@ -123,6 +123,8 @@ setup_args = dict(
         "nbext": ["notebook", "jupyter_server"],
         "serverextension": ["jupyter_server"],
         "labextension": ["jupyter_server", "jupyterlab>=3"],
+        "retroextension": ["jupyter_server", "retrolab"],
+        "benchmark": ["asv"],
         "test": [
             "pytest",
             "pytest-cov",


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/ipyparallel/gh-644-retro?urlpath=retro%2Ftree%2Fexamples)

## References
- starts #644

## Changes
- adds a binder with retrolab
  - adds (retro)lab (with shared editing +plugin)   
  - quick `depfinder` hit on `examples`
  - ipywidget (cuz always)
- in the retrolab `tree` adds a `IPython Parallel` tab
  - not much else works right now!
