### PR TITLE
Use chunksize in progress

### DIFF
--- a/ipyparallel/tests/test_asyncresult.py
+++ b/ipyparallel/tests/test_asyncresult.py
@@ -480,3 +480,11 @@ class AsyncResultTest(ClusterTestCase):
         done, pending = amr.wait(timeout=0, return_when=ipp.FIRST_EXCEPTION)
         assert pending == set()
         assert len(done) == len(amr)
+
+    def test_progress(self):
+        dv = self.client[:]
+        amr = dv.map_async(time.sleep, [0.2] * 2 * len(dv))
+        assert len(amr) == len(dv) * 2
+        assert amr.progress == 0
+        amr.wait_interactive()
+        assert amr.progress == len(amr)

--- a/ipyparallel/tests/test_lbview.py
+++ b/ipyparallel/tests/test_lbview.py
@@ -29,16 +29,19 @@ class TestLoadBalancedView(ClusterTestCase):
             return x ** 2
 
         data = list(range(16))
-        r = self.view.map_sync(f, data)
-        self.assertEqual(r, list(map(f, data)))
+        ar = self.view.map_async(f, data)
+        assert len(ar) == len(data)
+        r = ar.get()
+        assert r == list(map(f, data))
 
     def test_map_generator(self):
         def f(x):
             return x ** 2
 
         data = list(range(16))
-        r = self.view.map_sync(f, iter(data))
-        self.assertEqual(r, list(map(f, iter(data))))
+        ar = self.view.map_async(f, iter(data))
+        r = ar.get()
+        assert r == list(map(f, iter(data)))
 
     def test_map_short_first(self):
         def f(x, y):
@@ -51,8 +54,10 @@ class TestLoadBalancedView(ClusterTestCase):
         data = list(range(10))
         data2 = list(range(4))
 
-        r = self.view.map_sync(f, data, data2)
-        self.assertEqual(r, list(map(f, data, data2)))
+        ar = self.view.map_async(f, data, data2)
+        assert len(ar) == len(data2)
+        r = ar.get()
+        assert r == list(map(f, data, data2))
 
     def test_map_short_last(self):
         def f(x, y):
@@ -65,8 +70,10 @@ class TestLoadBalancedView(ClusterTestCase):
         data = list(range(4))
         data2 = list(range(10))
 
-        r = self.view.map_sync(f, data, data2)
-        self.assertEqual(r, list(map(f, data, data2)))
+        ar = self.view.map_async(f, data, data2)
+        assert len(ar) == len(data)
+        r = ar.get()
+        assert r == list(map(f, data, data2))
 
     def test_map_unordered(self):
         def f(x):

--- a/ipyparallel/tests/test_view.py
+++ b/ipyparallel/tests/test_view.py
@@ -334,7 +334,9 @@ class TestView(ClusterTestCase):
             return x ** 2
 
         data = list(range(16))
-        r = view.map_sync(f, data)
+        ar = view.map_async(f, data)
+        assert len(ar) == len(data)
+        r = ar.get()
         self.assertEqual(r, list(map(f, data)))
 
     def test_map_empty_sequence(self):
@@ -361,7 +363,9 @@ class TestView(ClusterTestCase):
         view = self.client[:]
         # 101 is prime, so it won't be evenly distributed
         arr = numpy.arange(101)
-        r = view.map_sync(lambda x: x, arr)
+        ar = view.map_async(lambda x: x, arr)
+        assert len(ar) == len(arr)
+        r = ar.get()
         assert_array_equal(r, arr)
 
     def test_scatter_gather_nonblocking(self):
@@ -369,7 +373,7 @@ class TestView(ClusterTestCase):
         view = self.client[:]
         view.scatter('a', data, block=False)
         ar = view.gather('a', block=False)
-        self.assertEqual(ar.get(), data)
+        assert ar.get() == data
 
     @skip_without('numpy')
     def test_scatter_gather_numpy_nonblocking(self):


### PR DESCRIPTION
len(AMR) and AMR.progress represent the number of inputs, _not_ the number of messages

Mainly produces more intuitive reporting of progress for DirectView.map

Reporting granularity is unchanged, as each chunk will still only be updated once, but at least it will be the expected number

closes #217