### PR TITLE
add pbs to ipyparallel.engine_launchers entry_points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,7 @@ setup_args = dict(
             'local = ipyparallel.cluster.launcher:LocalEngineSetLauncher',
             'lsf = ipyparallel.cluster.launcher:LSFEngineSetLauncher',
             'mpi = ipyparallel.cluster.launcher:MPIEngineSetLauncher',
+            'pbs = ipyparallel.cluster.launcher:PBSEngineSetLauncher',
             'sge = ipyparallel.cluster.launcher:SGEEngineSetLauncher',
             'slurm = ipyparallel.cluster.launcher:SlurmEngineSetLauncher',
             'ssh = ipyparallel.cluster.launcher:SSHEngineSetLauncher',


### PR DESCRIPTION
It seems to have been left out by mistake and prevents using the "pbs" shortcut for specifying the engine launcher.

e.g. this currently fails

```
cluster=ipp.Cluster(
    n=128, 
    controller_ip='*',
    controller="pbs",
    engines="pbs",
)
```
but this works

```
cluster=ipp.Cluster(
    n=128, 
    controller_ip='*',
    controller="pbs",
    engines="ipyparallel.cluster.launcher.PBSEngineSetLauncher",
)
