### PR TITLE
Fix engine id, show %px output on error

### DIFF
--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -990,7 +990,7 @@ class AsyncResult(Future):
         stderrs = self.stderr
         execute_results = self.execute_result
         output_lists = self.outputs
-        results = self.get()
+        results = self.get(return_exceptions=True)
 
         targets = self.engine_id
 

--- a/ipyparallel/tests/__init__.py
+++ b/ipyparallel/tests/__init__.py
@@ -124,7 +124,7 @@ def teardown():
             try:
                 f = p.stop()
                 if f:
-                    asyncio.run(f)
+                    asyncio.get_event_loop().run_until_complete(f)
             except Exception as e:
                 print(e)
                 pass

--- a/ipyparallel/tests/test_asyncresult.py
+++ b/ipyparallel/tests/test_asyncresult.py
@@ -288,6 +288,20 @@ class AsyncResultTest(ClusterTestCase):
         self.assertEqual(io.stderr, '')
         self.assertEqual(io.stdout, '')
 
+    def test_display_output_error(self):
+        """display_outputs shows output on error"""
+        self.minimum_engines(1)
+
+        v = self.client[-1]
+        ar = v.execute("print (5555)\n1/0")
+        ar.get(5, return_exceptions=True)
+        ar.wait_for_output(5)
+        with capture_output() as io:
+            ar.display_outputs()
+        self.assertEqual(io.stderr, '')
+        self.assertEqual('5555\n', io.stdout)
+        assert 'ZeroDivisionError' not in io.stdout
+
     def test_await_data(self):
         """asking for ar.data flushes outputs"""
         self.minimum_engines(1)


### PR DESCRIPTION
fixes #661 

The streaming-or-not logic is consolidated a bit to reduce repetition (the same errors no longer need to be caught twice).