### PR TITLE
Added mpi4py requirement to MPI example

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -60,7 +60,7 @@ with ipp.Cluster() as rc:
 <source src="_static/basic.mp4"/>
 </video>
 
-You can similarly run MPI code using IPyParallel:
+You can similarly run MPI code using IPyParallel (requires [mpi4py](https://mpi4py.readthedocs.io/en/stable/install.html)):
 
 ```python
 import ipyparallel as ipp


### PR DESCRIPTION
The basic MPI example on the doc index page only works if `mpi4py` is installed, this should be mentioned somewhere as it leads to errors which may confuse a beginner. I have added a reference to mpi4py's installation doc.