### PR TITLE
setup.py fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
+import glob
 import os
 import sys
 
@@ -61,14 +62,35 @@ if '' not in sys.path:
     sys.path.insert(0, '')
 from setupbase import wrap_installers, npm_builder, get_data_files
 
-data_files = get_data_files(data_files_spec)
-
 builder = npm_builder(build_cmd="build:prod", npm="jlpm")
+
+cmdclass = {}
 if os.environ.get("IPP_DISABLE_JS") == "1":
     print("Skipping js installation")
-    cmdclass = {}
 else:
-    cmdclass = wrap_installers(pre_develop=builder, pre_dist=builder)
+    # this tells us if labextension is built at all, not if it's up-to-date
+    labextension_built = glob.glob(os.path.join(lab_path, "*"))
+    if not labextension_built:
+        # jupyter-packaging doesn't update data_files or package_data correctly
+        # after running builds
+        # run build first if we know it's needed
+        builder()
+        # don't need to run it again
+        needs_js = False
+
+    needs_js = True
+    if not os.path.isdir(os.path.join(here, ".git")):
+        print("Installing from a dist, not a repo")
+        # not in a repo, probably installing from sdist
+        # could be git-archive, though!
+        # skip rebuilding js if it's already present
+        if labextension_built:
+            print(f"Not regenerating labextension in {lab_path}")
+            needs_js = False
+
+    if needs_js:
+        cmdclass = wrap_installers(pre_develop=builder, pre_dist=builder)
+
 
 if "bdist_egg" not in sys.argv:
     cmdclass["bdist_egg"] = bdist_egg_disabled
@@ -78,7 +100,7 @@ setup_args = dict(
     version=version_ns["__version__"],
     packages=setuptools.find_packages(),
     description="Interactive Parallel Computing with IPython",
-    data_files=data_files,
+    data_files=get_data_files(data_files_spec),
     long_description=readme,
     long_description_content_type="text/markdown",
     author="IPython Development Team",


### PR DESCRIPTION
- update jupyter-packaging to 0.12 (fixes compatibility with setuptools 61)
- workaround https://github.com/jupyter/jupyter-packaging/pull/127 by ensuring build has been run once prior to computing data_files
- avoid redundant rebuild of js when installing from sdists (closes #675)
 