### PR TITLE
pin jinja due to deprecated API used by nbconvert

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+# pin jinja2 due to broken deprecation used in nbconvert
+jinja2==3.0.*
 matplotlib
 myst-parser
 nbsphinx


### PR DESCRIPTION
removed in jinja 3.1