### PR TITLE
Clean up testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ on:
       - "*"
   pull_request:
 
+concurrency:
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build-release:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,13 @@ on:
     branches-ignore:
       - "pre-commit-ci*"
 
+concurrency:
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   # UTF-8 content may be interpreted as ascii and causes errors without this.
   LANG: C.UTF-8
@@ -28,9 +35,8 @@ jobs:
           - python: "3.7"
             cluster_type: slurm
             container: slurmctld
-          - python: "3.6"
-            tornado: "5.1.1"
           - python: "3.7"
+          - python: "3.8"
             env:
               IPP_CONTROLLER_IP: "*"
           - python: "3.9"
@@ -113,11 +119,6 @@ jobs:
           pip install --pre --upgrade .[test] distributed joblib codecov
           pip install --only-binary :all: matplotlib || echo "no matplotlib"
 
-      - name: Install pinned tornado
-        if: matrix.tornado
-        run: |
-          pip install tornado==${{ matrix.tornado }}
-
       - name: Show environment
         run: pip freeze
 
@@ -128,14 +129,12 @@ jobs:
       - name: Run ${{ matrix.cluster_type }} tests
         if: ${{ matrix.cluster_type }}
         run: |
-          ${EXEC:-} pytest -ra -v --maxfail=2 --color=yes --cov=ipyparallel ipyparallel/tests/test_${{ matrix.cluster_type }}.py
+          ${EXEC:-} pytest -v --maxfail=2 --cov=ipyparallel ipyparallel/tests/test_${{ matrix.cluster_type }}.py
 
       - name: Run tests
         if: ${{ ! matrix.cluster_type }}
-        # FIXME: --color=yes explicitly set because:
-        #        https://github.com/actions/runner/issues/241
         run: |
-          pytest -ra -v --maxfail=3 --color=yes --cov=ipyparallel ipyparallel/tests
+          pytest -v --maxfail=3 --cov=ipyparallel
 
       - name: Fixup coverage permissions ${{ matrix.container }}
         if: ${{ matrix.container }}

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1036,11 +1036,9 @@ class Client(HasTraits):
         """Make my IOLoop. Override with IOLoop.current to return"""
         # runs first thing in the io thread
         # always create a fresh asyncio loop for the thread
+        if os.name == "nt":
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         asyncio_loop = asyncio.new_event_loop()
-        if hasattr(asyncio, 'ProactorEventLoop') and isinstance(
-            asyncio_loop, asyncio.ProactorEventLoop
-        ):
-            asyncio_loop = asyncio.SelectorEventLoop()
         asyncio.set_event_loop(asyncio_loop)
         loop = ioloop.IOLoop()
         loop.make_current()
@@ -1077,7 +1075,7 @@ class Client(HasTraits):
         self._io_thread.daemon = True
         self._io_thread.start()
         # wait for the IOLoop to start
-        for i in range(10):
+        for i in range(20):
             if evt.wait(1):
                 return
             if not self._io_thread.is_alive():

--- a/ipyparallel/controller/sqlitedb.py
+++ b/ipyparallel/controller/sqlitedb.py
@@ -19,7 +19,7 @@ from dateutil.parser import parse as dateutil_parse
 from tornado import ioloop
 
 from traitlets import Unicode, Instance, List, Dict
-from jupyter_client.jsonutil import date_default
+from jupyter_client.jsonutil import json_default
 
 from .dictdb import BaseDB
 from ..util import ensure_timezone, extract_dates
@@ -49,7 +49,7 @@ null_operators = {
 
 
 def _adapt_dict(d):
-    return json.dumps(d, default=date_default)
+    return json.dumps(d, default=json_default)
 
 
 def _convert_dict(ds):

--- a/ipyparallel/tests/conftest.py
+++ b/ipyparallel/tests/conftest.py
@@ -4,8 +4,10 @@ import logging
 import os
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 from subprocess import check_call
 from subprocess import check_output
+from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
 from unittest import mock
 
@@ -14,12 +16,24 @@ import pytest
 import zmq
 from IPython.core.profiledir import ProfileDir
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
-from IPython.testing.tools import default_config
 from traitlets.config import Config
 
 import ipyparallel as ipp
 from . import setup
 from . import teardown
+
+
+def default_config():
+    """Return a config object with good defaults for testing."""
+    config = Config()
+    config.TerminalInteractiveShell.colors = 'NoColor'
+    config.TerminalTerminalInteractiveShell.term_title = (False,)
+    config.TerminalInteractiveShell.autocall = 0
+    f = NamedTemporaryFile(suffix='test_hist.sqlite', delete=False)
+    config.HistoryManager.hist_file = str(Path(f.name))
+    f.close()
+    config.HistoryManager.db_cache_size = 10000
+    return config
 
 
 @contextmanager

--- a/ipyparallel/tests/test_apps.py
+++ b/ipyparallel/tests/test_apps.py
@@ -115,6 +115,7 @@ def test_bind_kernel(request):
             io_loop=create_autospec(spec=ioloop.IOLoop, spec_set=True, instance=True),
         )
     ]
+
     app.kernel.control_stream = zmqstream.ZMQStream(
         socket=socket_spec(),
         io_loop=create_autospec(spec=ioloop.IOLoop, spec_set=True, instance=True),
@@ -122,6 +123,7 @@ def test_bind_kernel(request):
 
     # testing the case iopub_socket is not replaced with IOPubThread
     iopub_socket = socket_spec()
+
     app.kernel.iopub_socket = iopub_socket
     assert isinstance(app.kernel.iopub_socket, zmq.Socket)
     bind_kernel(app)
@@ -230,6 +232,7 @@ def test_ipcluster_start_stop(request, ipython_dir, daemonize):
 
     # cluster running, try to connect with default args
     cluster = ipp.Cluster.from_file(log_level=10)
+
     try:
         with cluster.connect_client_sync() as rc:
             rc.wait_for_engines(n=2, timeout=60)

--- a/ipyparallel/tests/test_cluster.py
+++ b/ipyparallel/tests/test_cluster.py
@@ -350,6 +350,7 @@ async def test_cluster_manager_notice_stop(Cluster):
     assert key not in cm.clusters
 
 
+@pytest.mark.skipif(os.name == 'nt', reason="Does not work on Windows")
 async def test_wait_for_engines_crash(Cluster):
     """wait_for_engines is cancelled when the engines stop"""
     c = Cluster(n=2, log_level=10)

--- a/ipyparallel/tests/test_db.py
+++ b/ipyparallel/tests/test_db.py
@@ -274,7 +274,9 @@ class TestSQLiteBackend(TaskDBTest, TestCase):
     def setUp(self):
         # make a new IOLoop
         IOLoop().make_current()
-        self.temp_db = tempfile.NamedTemporaryFile(suffix='.db').name
+        tmp_file = tempfile.NamedTemporaryFile(suffix='.db')
+        self.temp_db = tmp_file.name
+        tmp_file.close()
         super().setUp()
 
     def create_db(self):

--- a/ipyparallel/tests/test_joblib.py
+++ b/ipyparallel/tests/test_joblib.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import mock
 
 import pytest
@@ -7,8 +8,10 @@ from .clienttest import add_engines
 from .clienttest import ClusterTestCase
 
 try:
-    from joblib import Parallel, delayed
-    from ipyparallel.client._joblib import IPythonParallelBackend  # noqa
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from joblib import Parallel, delayed
+        from ipyparallel.client._joblib import IPythonParallelBackend  # noqa
 except (ImportError, TypeError):
     have_joblib = False
 else:

--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -601,12 +601,15 @@ def utcnow():
     return datetime.utcnow().replace(tzinfo=utc)
 
 
+def _v(version_s):
+    return tuple(int(s) for s in re.findall(r"\d+", version_s))
+
+
 def _patch_jupyter_client_dates():
     """Monkeypatch jupyter_client.extract_dates to be nondestructive wrt timezone info"""
     import jupyter_client
-    from distutils.version import LooseVersion as V
 
-    if V(jupyter_client.__version__) < V('5.0'):
+    if _v(jupyter_client.__version__) < _v('5.0'):
         from jupyter_client import session
 
         if hasattr(session, '_save_extract_dates'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,25 @@ target_version = [
     "py38",
 ]
 
+[tool.pytest.ini_options]
+addopts = "-raXs --durations 10 --color=yes"
+asyncio_mode = "auto"
+testpaths = [
+    "ipyparallel/tests"
+]
+filterwarnings = [
+  "error",
+  "ignore:unclosed event loop:ResourceWarning",
+  "ignore:unclosed socket <zmq.Socket:ResourceWarning",
+  "ignore:unclosed <socket.socket:ResourceWarning",
+  "ignore:unclosed file <_io.BufferedWriter:ResourceWarning",
+  "ignore:subprocess .* is still running:ResourceWarning",
+  "ignore:unclosed file <_io.BufferedRandom>:ResourceWarning",
+  # from older versions of ipykernel
+  "ignore:the imp module is:DeprecationWarning",
+]
+
+
 [tool.tbump]
 # Uncomment this if your project is hosted on GitHub:
 github_url = "https://github.com/jupyterhub/jupyterhub"

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,6 @@ setup_args = dict(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -140,7 +139,7 @@ setup_args = dict(
         "python-dateutil>=2.1",
         "tqdm",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     extras_require={
         "nbext": ["notebook", "jupyter_server"],
         "serverextension": ["jupyter_server"],


### PR DESCRIPTION
- Added more pytest config from `jupyter_server` and handled as many warnings as possible
- Bumped Python Version support to 3.7+ because Python 3.6 does not support the `asyncio_mode` setting
- Fixed Windows tests, but had to skip a couple

I tried to get Python 3.10 support, but I was having trouble preventing the warnings from causing errors despite being ignored.  It could be done as a follow on effort.