### PR TITLE
only skip redisplay of streamed errors if outputs are complete

### DIFF
--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -422,7 +422,7 @@ class ParallelMagics(Magics):
                     try:
                         result.get()
                     except error.CompositeError as e:
-                        if stream_output:
+                        if stream_output and result._output_ready:
                             # already streamed, show an abbreviated result
                             raise error.AlreadyDisplayedError(e) from None
                         else:


### PR DESCRIPTION
this allows for possibility of re-displaying _some_ errors if e.g. a subset of errors have been displayed, but not all outputs have arrived.

May close #707 but can't be sure