### PR TITLE
avoid use of deprecated global references to non-running loops

### DIFF
--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -6,7 +6,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
  rm -f /etc/apt/apt.conf.d/docker-clean \
  && apt-get update && apt-get -y install python3-pip slurm-wlm
 ENV PIP_CACHE_DIR=/tmp/pip-cache
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} python3 -m pip install ipyparallel pytest-asyncio pytest-cov pytest-tornado
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} python3 -m pip install ipyparallel pytest-asyncio pytest-cov
 RUN mkdir /var/spool/slurmctl \
  && mkdir /var/spool/slurmd
 COPY slurm.conf /etc/slurm-llnl/slurm.conf

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -1030,10 +1030,7 @@ class Client(HasTraits):
         # always create a fresh asyncio loop for the thread
         if os.name == "nt":
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        asyncio_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(asyncio_loop)
-        loop = ioloop.IOLoop()
-        loop.make_current()
+        loop = ioloop.IOLoop(make_current=False)
         return loop
 
     def _stop_io_thread(self):

--- a/ipyparallel/cluster/app.py
+++ b/ipyparallel/cluster/app.py
@@ -185,7 +185,7 @@ class IPClusterStop(BaseParallelApplication):
                 tasks.append(cluster.stop_cluster())
             await asyncio.gather(*tasks)
 
-        asyncio.get_event_loop().run_until_complete(_stop_all())
+        asyncio.run(_stop_all())
 
 
 list_aliases = {}

--- a/ipyparallel/controller/scheduler.py
+++ b/ipyparallel/controller/scheduler.py
@@ -134,8 +134,7 @@ def get_common_scheduler_streams(
         # in a process, don't use instance()
         # for safety with multiprocessing
         ctx = zmq.Context()
-        loop = ioloop.IOLoop()
-        loop.make_current()
+        loop = ioloop.IOLoop(make_current=False)
 
     def connect(s, addr):
         return util.connect(

--- a/ipyparallel/engine/kernel.py
+++ b/ipyparallel/engine/kernel.py
@@ -84,7 +84,7 @@ class IPythonParallelKernel(IPythonKernel):
 
         # if we have a delay, give messages this long to arrive on the queue
         # before we start accepting requests
-        asyncio.get_event_loop().call_later(
+        asyncio.get_running_loop().call_later(
             self.stop_on_error_timeout, schedule_stop_aborting
         )
 

--- a/ipyparallel/tests/__init__.py
+++ b/ipyparallel/tests/__init__.py
@@ -125,7 +125,7 @@ def teardown():
             try:
                 f = p.stop()
                 if f:
-                    asyncio.get_event_loop().run_until_complete(f)
+                    asyncio.run(f)
             except Exception as e:
                 print(e)
                 pass

--- a/ipyparallel/tests/conftest.py
+++ b/ipyparallel/tests/conftest.py
@@ -136,7 +136,6 @@ def cluster_config():
 def Cluster(
     request,
     ipython_dir,
-    io_loop,
     controller_launcher_class,
     engine_launcher_class,
     cluster_config,

--- a/ipyparallel/tests/test_client.py
+++ b/ipyparallel/tests/test_client.py
@@ -601,6 +601,7 @@ class TestClient(ClusterTestCase):
         tornado.version_info[:2] < (5,),
         reason="become_dask doesn't work with tornado 4",
     )
+    @pytest.mark.filterwarnings("ignore:make_current")
     def test_become_dask(self):
         executor = self.client.become_dask()
         reprs = self.client[:].apply_sync(repr, Reference('distributed_worker'))

--- a/ipyparallel/tests/test_db.py
+++ b/ipyparallel/tests/test_db.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 from unittest import TestCase
 
 from jupyter_client.session import Session
-from tornado.ioloop import IOLoop
 
 from ipyparallel import util
 from ipyparallel.controller.dictdb import DictDB
@@ -30,7 +29,7 @@ class TaskDBTest:
     def load_records(self, n=1, buffer_size=100):
         """load n records for testing"""
         # sleep 1/10 s, to ensure timestamp is different to previous calls
-        time.sleep(0.1)
+        time.sleep(0.01)
         msg_ids = []
         for i in range(n):
             msg = self.session.msg('apply_request', content=dict(a=5))
@@ -271,8 +270,6 @@ class TestDictBackend(TaskDBTest, TestCase):
 
 class TestSQLiteBackend(TaskDBTest, TestCase):
     def setUp(self):
-        # make a new IOLoop
-        IOLoop().make_current()
         tmp_file = tempfile.NamedTemporaryFile(suffix='.db')
         self.temp_db = tmp_file.name
         tmp_file.close()
@@ -290,4 +287,3 @@ class TestSQLiteBackend(TaskDBTest, TestCase):
             os.remove(self.temp_db)
         except:
             pass
-        IOLoop.clear_current()

--- a/ipyparallel/tests/test_executor.py
+++ b/ipyparallel/tests/test_executor.py
@@ -3,8 +3,6 @@
 # Distributed under the terms of the Modified BSD License.
 import time
 
-from tornado.ioloop import IOLoop
-
 from ipyparallel.client.view import LazyMapIterator, LoadBalancedView
 
 from .clienttest import ClusterTestCase
@@ -22,14 +20,11 @@ def echo(x):
 
 
 class AsyncResultTest(ClusterTestCase):
-    def resolve(self, future):
-        return IOLoop().run_sync(lambda: future)
-
     def test_client_executor(self):
         executor = self.client.executor()
         assert isinstance(executor.view, LoadBalancedView)
         f = executor.submit(lambda x: 2 * x, 5)
-        r = self.resolve(f)
+        r = f.result()
         self.assertEqual(r, 10)
 
     def test_view_executor(self):
@@ -41,7 +36,7 @@ class AsyncResultTest(ClusterTestCase):
         view = self.client.load_balanced_view()
         executor = view.executor
         f = executor.submit(lambda x, y: x * y, 2, 3)
-        r = self.resolve(f)
+        r = f.result()
         self.assertEqual(r, 6)
 
     def test_executor_map(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-asyncio",
-    "pytest-tornado",
     "ipython[test]",
     "testpath",
 ]


### PR DESCRIPTION
- asyncio.get_event_loop (Python 3.10)
- IOLoop.current (tornado 6.2)
- IOLoop.make_current()