### PR TITLE
Fix warning test

### DIFF
--- a/ipyparallel/tests/test_client.py
+++ b/ipyparallel/tests/test_client.py
@@ -626,23 +626,25 @@ class TestClient(ClusterTestCase):
                     c = self.connect_client()
                 c.close()
             with mock.patch('socket.gethostname', lambda: location):
+                c = None
                 try:
-                    c = self.connect_client()
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("error", category=RuntimeWarning)
+                        c = self.connect_client()
                 finally:
                     if c:
-                        warnings.simplefilter("ignore", category=RuntimeWarning)
                         c.close()
 
     def test_local_ip_true_doesnt_trigger_warning(self):
         with mock.patch('ipyparallel.client.client.is_local_ip', lambda x: True):
             c = None
-            with warnings.catch_warnings():
-                warnings.simplefilter("error")
-                try:
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", category=RuntimeWarning)
                     c = self.connect_client()
-                finally:
-                    if c:
-                        c.close()
+            finally:
+                if c:
+                    c.close()
 
     def test_wait_for_engines(self):
         n = len(self.client)


### PR DESCRIPTION
~~~
=================================== FAILURES ===================================
_____________ TestClient.test_local_ip_true_doesnt_trigger_warning _____________
self = <ipyparallel.tests.test_client.TestClient testMethod=test_local_ip_true_doesnt_trigger_warning>
    def test_local_ip_true_doesnt_trigger_warning(self):
        with mock.patch('ipyparallel.client.client.is_local_ip', lambda x: True):
            c = None
            with warnings.catch_warnings():
                warnings.simplefilter("error")
                try:
>                   c = self.connect_client()
ipyparallel/tests/test_client.py:642: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
ipyparallel/tests/clienttest.py:159: in connect_client
    s.setsockopt(zmq.LINGER, 0)
zmq/backend/cython/socket.pyx:411: in zmq.backend.cython.socket.Socket.set
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
>   ???
E   zmq.error.ZMQError: Socket operation on non-socket
zmq/backend/cython/socket.pyx:135: ZMQError
~~~
