### PR TITLE
DOCS: Making 'DAG Dependencies' tutorial runnable and more consistent

### DIFF
--- a/docs/source/reference/dag_dependencies.md
+++ b/docs/source/reference/dag_dependencies.md
@@ -2,12 +2,11 @@
 
 # DAG Dependencies
 
-Often, parallel workflow is described in terms of a [Directed Acyclic Graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) or DAG. A popular library
-for working with Graphs is [NetworkX]. Here, we will walk through a demo mapping
-a nx DAG to task dependencies.
+Often, parallel workflow is described in terms of a [Directed Acyclic Graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph)
+or DAG. A popular library for working with Graphs is [NetworkX]. Here, we will walk through
+a demo mapping a NetworkX DAG to task dependencies.
 
-The full script that runs this demo can be found in
-{file}`examples/parallel/dagdeps.py`.
+The full script that runs this demo can be found in {file}`examples/parallel/dagdeps.py`.
 
 ## Why are DAGs good for task dependencies?
 
@@ -21,80 +20,95 @@ because if a loop were closed, then a task could ultimately depend on itself, an
 able to run. If your workflow can be described as a DAG, then it is impossible for your
 dependencies to cause a deadlock.
 
-## A Sample DAG
+## A sample DAG
 
-Here, we have a very simple 5-node DAG:
+Suppose we have five tasks, and they depend on each other as follows:
+
+- Task 0 has no dependencies and can run right away.
+- When 0 finishes, tasks 1 and 2 can start.
+- When 1 finishes, task 3 must wait for 2, but task 4 can start right away.
+- When 2 finishes, task 3 can finally start.
+
+We might represent these tasks with a simple graph:
 
 ```{figure} figs/simpledag.*
 :width: 600px
 ```
 
-With NetworkX, an arrow is a fattened bit on the edge. Here, we can see that task 0
-depends on nothing, and can run immediately. 1 and 2 depend on 0; 3 depends on
-1 and 2; and 4 depends only on 1.
+An arrow is repsented here by a fattened bit on the edge. As we specified when we made the
+edges, we can see that task 0 depends on nothing, and can run immediately. 1 and 2 depend
+on 0; 3 depends on 1 and 2; and 4 depends only on 1.
 
-A possible sequence of events for this workflow:
+Let's construct this 5-node DAG. First, we create a directed graph or 'digraph':
 
-0. Task 0 can run right away
-1. 0 finishes, so 1,2 can start
-2. 1 finishes, 3 is still waiting on 2, but 4 can start right away
-3. 2 finishes, and 3 can finally start
+```ipython
+In [1]: import networkx as nx
 
-Further, taking failures into account, assuming all dependencies are run with the default
-`success=True,failure=False`, the following cases would occur for each node's failure:
+In [2]: G = nx.DiGraph()
 
-0. fails: all other tasks fail as Impossible
-1. 2 can still succeed, but 3,4 are unreachable
-2. 3 becomes unreachable, but 4 is unaffected
-3. and 4. are terminal, and can have no effect on other nodes
-
-The code to generate the simple DAG:
-
-```python
-import networkx as nx
-
-G = nx.DiGraph()
-
-# add 5 nodes, labeled 0-4:
-map(G.add_node, range(5))
-# 1,2 depend on 0:
-G.add_edge(0,1)
-G.add_edge(0,2)
-# 3 depends on 1,2
-G.add_edge(1,3)
-G.add_edge(2,3)
-# 4 depends on 1
-G.add_edge(1,4)
-
-# now draw the graph:
-pos = { 0 : (0,0), 1 : (1,1), 2 : (-1,1),
-        3 : (0,2), 4 : (2,2)}
-nx.draw(G, pos, edge_color='r')
+In [3]: map(G.add_node, range(5))  # Add 5 nodes, labeled 0-4.
 ```
+
+Now we can add edges:
+
+```ipython
+In [4]: G.add_edge(0, 1)  # Task 1 depends on task 0...
+
+In [5]: G.add_edge(0, 2)  # ...and so does task 2.
+
+In [6]: G.add_edge(1, 3)  # Task 3 depends on task 1...
+
+In [7]: G.add_edge(2, 3)  # ...and also on task 2.
+
+In [8]: G.add_edge(1, 4)  # Task 4 depends on task 1.
+```
+
+The following code produces the figure above:
+
+```ipython
+In [9]: pos = {0: (0, 0), 1: (1, 1), 2: (-1, 1),
+   ...:        3: (0, 2), 4: (2, 2)}
+In [10]: nx.draw(G, pos, edge_color='r')
+```
+
+Taking failures into account, assuming all dependencies are run with the default
+`success=True, failure=False`, the following cases would occur for each node's failure:
+
+0. All other tasks fail as impossible.
+1. 2 can still succeed, but 3 and 4 are unreachable.
+2. 3 becomes unreachable, but 4 is unaffected.
+3. and 4. are terminal, and can have no effect on other nodes.
+
+Let's look at a larger, more complex network.
+
+## Computing with a random DAG
 
 For demonstration purposes, we have a function that generates a random DAG with a given
 number of nodes and edges.
 
 ```{literalinclude} ../examples/dagdeps.py
 :language: python
-:lines: 20-36
+:lines: 24-40
 ```
 
 So first, we start with a graph of 32 nodes, with 128 edges:
 
 ```ipython
-In [2]: G = random_dag(32,128)
+In [11]: G = random_dag(32, 128)
 ```
 
-Now, we need to build our dict of jobs corresponding to the nodes on the graph:
+Then we need some jobs. In reality these would all be different, but for our toy example 
+we'll use a single function that sleeps for a random interval:
+
+```{literalinclude} ../examples/dagdeps.py
+:language: python
+:lines: 16-21
+```
+
+Now we can build our dict of jobs corresponding to the nodes on the graph:
 
 ```ipython
-In [3]: jobs = {}
-
-# in reality, each job would presumably be different
-# randomwait is a function that sleeps for a random interval
-In [4]: for node in G:
-   ...:     jobs[node] = randomwait
+In [12]: jobs = {n: randomwait for n in G}
 ```
 
 Once we have a dict of jobs matching the nodes on the graph, we can start submitting jobs,
@@ -102,33 +116,38 @@ and linking up the dependencies. Since we don't know a job's msg_id until it is 
 which is necessary for building dependencies, it is critical that we don't submit any jobs
 before other jobs it may depend on. Fortunately, NetworkX provides a
 {meth}`topological_sort` method which ensures exactly this. It presents an iterable, that
-guarantees that when you arrive at a node, you have already visited all the nodes it
-on which it depends:
+guarantees that when you arrive at a node, you have already visited all the nodes on which
+it depends:
 
 ```ipython
-In [5]: rc = ipp.Client()
-In [5]: view = rc.load_balanced_view()
+In [13]: import ipyprallel as ipp
 
-In [6]: results = {}
+In [14]: rc = ipp.Client()
 
-In [7]: for node in nx.topological_sort(G):
-   ...:    # get list of AsyncResult objects from nodes
-   ...:    # leading into this one as dependencies
-   ...:    deps = [ results[n] for n in G.predecessors(node) ]
-   ...:    # submit and store AsyncResult object
-   ...:    with view.temp_flags(after=deps, block=False):
-   ...:         results[node] = view.apply(jobs[node])
+In [15]: view = rc.load_balanced_view()
+
+In [16]: results = {}
+
+In [17]: for node in nx.topological_sort(G):
+    ...:     # Get list of AsyncResult objects from nodes
+    ...:     # leading into this one as dependencies.
+    ...:     deps = [results[n] for n in G.predecessors(node)]
+    ...:     # Submit and store AsyncResult object.
+    ...:     with view.temp_flags(after=deps, block=False):
+    ...:         results[node] = view.apply(jobs[node])
 ```
 
 Now that we have submitted all the jobs, we can wait for the results:
 
 ```ipython
-In [8]: view.wait(results.values())
+In [18]: view.wait(results.values())
 ```
 
-Now, at least we know that all the jobs ran and did not fail (`r.get()` would have
-raised an error if a task failed). But we don't know that the ordering was properly
-respected. For this, we can use the {attr}`metadata` attribute of each AsyncResult.
+Now, at least we know that all the jobs ran and did not fail. But we don't know that
+the ordering was properly respected. For this, we can use the {attr}`metadata` attribute
+of each AsyncResult.
+
+## Inspecting the metadata
 
 These objects store a variety of metadata about each task, including various timestamps.
 We can validate that the dependencies were respected by checking that each task was
@@ -136,8 +155,16 @@ started after all of its predecessors were completed:
 
 ```{literalinclude} ../examples/dagdeps.py
 :language: python
-:lines: 64-70
+:lines: 72-81
 ```
+
+Then we can call this function:
+
+```ipython
+In [19]: validate_tree(G, results)
+```
+
+It produces no output but the assertions pass.
 
 We can also validate the graph visually. By drawing the graph with each node's x-position
 as its start time, all arrows must be pointing to the right if dependencies were respected.
@@ -145,28 +172,29 @@ For spreading, the y-position will be the runtime of the task, so long tasks
 will be at the top, and quick, small tasks will be at the bottom.
 
 ```ipython
-In [10]: from matplotlib.dates import date2num
+In [20]: from matplotlib.dates import date2num
 
-In [11]: from matplotlib.cm import gist_rainbow
+In [21]: from matplotlib.cm import gist_rainbow
 
-In [12]: pos = {}; colors = {}
+In [22]: pos, colors = {}, {}
 
-In [12]: for node in G:
-   ....:    md = results[node].metadata
-   ....:    start = date2num(md.started)
-   ....:    runtime = date2num(md.completed) - start
-   ....:    pos[node] = (start, runtime)
-   ....:    colors[node] = md.engine_id
+In [23]: for node in G:
+    ...:     md = results[node].metadata
+    ...:     start = date2num(md.started)
+    ...:     runtime = date2num(md.completed) - start
+    ...:     pos[node] = (start, runtime)
+    ...:     colors[node] = md.engine_id
 
-In [13]: nx.draw(G, pos, node_list=colors.keys(), node_color=colors.values(),
-   ....:    cmap=gist_rainbow)
+In [24]: nx.draw(G, pos, nodelist=colors.keys(), node_color=list(colors.values()),
+    ...:     cmap=gist_rainbow)
 ```
 
 ```{figure} figs/dagdeps.*
 :width: 600px
 
-Time started on x, runtime on y, and color-coded by engine-id (in this case there
-were four engines). Edges denote dependencies.
+Time started on the x-axis, runtime on the y-axis, and color-coded by engine-id (in this 
+case there were four engines). Edges denote dependencies. The limits of the axes have been 
+adjusted in this plot.
 ```
 
 [networkx]: https://networkx.org


### PR DESCRIPTION
My main motivation: the code examples on this page were completely broken. Here's what I ended up doing:

- Make sure the code on the page _mostly_ runs; it maybe requires one small change to `examples/dagdeps.py` to make it clearer what `randint()` is. (`import random` instead of `from random import randint`)
- Correct the line numbers being pulled in from `dagdeps.py`.
- Reorder the introduction a bit to make it more readable (IMO).
- Make the code styling more consistent and PEP8-ish, and with correct enumeration.
- Removed a remark about `r.get()`, which is not found anywhere in the code.
- Added a couple of subheadings to make it clear there's more than one example/workflow here.