### PR TITLE
add $IPP_NONINTERACTIVE env

### DIFF
--- a/ipyparallel/__init__.py
+++ b/ipyparallel/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 # export return_when constants
+import os
 from concurrent.futures import ALL_COMPLETED  # noqa
 from concurrent.futures import FIRST_COMPLETED  # noqa
 from concurrent.futures import FIRST_EXCEPTION  # noqa
@@ -100,3 +101,5 @@ def _load_jupyter_server_extension(app):
 
 # backward-compat
 load_jupyter_server_extension = _load_jupyter_server_extension
+
+_NONINTERACTIVE = os.getenv("IPP_NONINTERACTIVE", "") not in {"", "0"}

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -45,6 +45,7 @@ from traitlets import (
 from traitlets.config.configurable import MultipleInstanceError
 from zmq.eventloop.zmqstream import ZMQStream
 
+import ipyparallel as ipp
 from ipyparallel import error, serialize, util
 from ipyparallel.serialize import PrePickled, Reference
 
@@ -1502,7 +1503,10 @@ class Client(HasTraits):
             seconds_remaining = 1000
 
         if interactive is None:
-            interactive = get_ipython() is not None
+            if ipp._NONINTERACTIVE:
+                interactive = False
+            else:
+                interactive = get_ipython() is not None
 
         if interactive:
             progress_bar = util.progress(

--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -51,6 +51,8 @@ from IPython.core import magic_arguments
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics
 
+import ipyparallel as ipp
+
 from .. import error
 
 # -----------------------------------------------------------------------------
@@ -245,7 +247,7 @@ class ParallelMagics(Magics):
     # verbose flag
     verbose = False
     # streaming output flag
-    stream_ouput = True
+    stream_output = not ipp._NONINTERACTIVE
     # seconds to wait before showing progress bar for blocking execution
     progress_after_seconds = 2
     # signal to send to engines on keyboard-interrupt
@@ -299,7 +301,7 @@ class ParallelMagics(Magics):
         if args.set_verbose is not None:
             self.verbose = args.set_verbose
         if args.stream is not None:
-            self.stream_ouput = args.stream
+            self.stream_output = args.stream
         if args.signal_on_interrupt is not None:
             self.signal_on_interrupt = self._eval_signal_str(args.signal_on_interrupt)
 
@@ -371,7 +373,7 @@ class ParallelMagics(Magics):
 
         # defaults:
         block = self.view.block if block is None else block
-        stream_output = self.stream_ouput if stream_output is None else stream_output
+        stream_output = self.stream_output if stream_output is None else stream_output
         signal_on_interrupt = (
             self.signal_on_interrupt
             if signal_on_interrupt is None


### PR DESCRIPTION
allows switching off the default progress bars with IPP_NONINTERACTIVE=1

mostly useful for building on CI (e.g. with jupyter-book)