### PR TITLE
fix wait_interactive(return_when=FIRST_EXCEPTION) when there are no errors

### DIFF
--- a/ipyparallel/client/asyncresult.py
+++ b/ipyparallel/client/asyncresult.py
@@ -876,7 +876,7 @@ class AsyncResult(Future):
                 if return_when == FIRST_COMPLETED:
                     finished = bool(done)
                 elif return_when == FIRST_EXCEPTION:
-                    finished = any(not ar._success for ar in done)
+                    finished = (not pending) or any(not ar._success for ar in done)
                 else:
                     raise ValueError(f"Unrecognized return_when={return_when!r}")
 


### PR DESCRIPTION
it wouldn't return if no error was raised