### PR TITLE
Disable variable expansion in %px

### DIFF
--- a/ipyparallel/client/magics.py
+++ b/ipyparallel/client/magics.py
@@ -49,7 +49,7 @@ from textwrap import dedent
 
 from IPython.core import magic_arguments
 from IPython.core.error import UsageError
-from IPython.core.magic import Magics
+from IPython.core.magic import Magics, no_var_expand
 
 import ipyparallel as ipp
 
@@ -341,6 +341,7 @@ class ParallelMagics(Magics):
         self.last_result.get()
         self.last_result.display_outputs(groupby=args.groupby)
 
+    @no_var_expand
     def px(self, line=''):
         """Executes the given python command in parallel.
 


### PR DESCRIPTION
avoids interpreting local vars when they should be remote, e.g.

```
%px print(f"Engine pid: {os.getpid()} 
```

The `no_var_expand` decorator is generally applied to most magics that accept _code_ as an input, like `%timeit`.


cc @jorgensd