### PR TITLE
Fix AttributeError: 'super' object has no attribute 'teardown'

### DIFF
--- a/ipyparallel/tests/test_view_broadcast.py
+++ b/ipyparallel/tests/test_view_broadcast.py
@@ -27,8 +27,8 @@ class TestBroadcastView(test_view.TestView):
 
         self.client.direct_view = broadcast_or_direct
 
-    def teardown(self):
-        super().teardown()
+    def teardown_method(self):
+        super().teardown_method()
         # note that a test didn't use a broadcast view
         if not self._broadcast_view_used:
             pytest.skip("No broadcast view used")


### PR DESCRIPTION
61 tests affected:

= 441 passed, 46 skipped, 11 xfailed, 8 xpassed, 2 warnings, 61 errors in 261.58s (0:04:21) =

First failure (all are similar):
~~~
______ ERROR at teardown of TestBroadcastViewCoalescing.test_z_crash_mux _______ self = <ipyparallel.tests.test_view_broadcast.TestBroadcastViewCoalescing object at 0x3ff4c58f370>
    def teardown(self):
>       super().teardown()
E       AttributeError: 'super' object has no attribute 'teardown'
ipyparallel/tests/test_view_broadcast.py:31: AttributeError
~~~
