### PR TITLE
don't propagate logs in IPython

### DIFF
--- a/ipyparallel/cluster/cluster.py
+++ b/ipyparallel/cluster/cluster.py
@@ -270,6 +270,7 @@ class Cluster(AsyncFirst, LoggingConfigurable):
 
             handler = logging.StreamHandler(sys.stdout)
             log.handlers = [handler]
+            log.propagate = False
             return log
         elif self.parent and getattr(self.parent, 'log', None) is not None:
             return self.parent.log


### PR DESCRIPTION
if a root logger is registered, our logs will be duplicated