### PR TITLE
make wait_for_send more reliable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           - python: "3.8"
             runs_on: windows-2019
           - python: "3.9"
-            runs_on: macos-10.15
+            runs_on: macos-11
           - python: "3.11"
 
     steps:

--- a/ipyparallel/tests/test_asyncresult.py
+++ b/ipyparallel/tests/test_asyncresult.py
@@ -395,13 +395,16 @@ class TestAsyncResult(ClusterTestCase):
     def test_wait_for_send(self):
         view = self.client[-1]
         view.track = True
+
         with pytest.raises(TimeoutError):
             # this test can fail if the send happens too quickly
             # e.g. the IO thread takes control for too long,
             # so run the test a few times
-            for i in range(10):
+            for i in range(3):
                 if i > 0:
                     print("Retrying test_wait_for_send")
+                # inject delay in io loop so send doesn't complete immediately
+                self.client._io_loop.add_callback(lambda: time.sleep(0.5))
                 data = os.urandom(10 * 1024 * 1024)
                 ar = view.apply_async(lambda x: x, data)
                 ar.wait_for_send(0)


### PR DESCRIPTION
by injecting a time.sleep 'bubble' into the io thread, to ensure send doesn't complete immediately.