### PR TITLE
Use pre-3.10 serialization code on PyPy3.10

### DIFF
--- a/ipyparallel/serialize/codeutil.py
+++ b/ipyparallel/serialize/codeutil.py
@@ -27,7 +27,8 @@ _code_attr_map = {
 }
 # pass every supported arg to the code constructor
 # this should be more forward-compatible
-if sys.version_info >= (3, 10):
+# (broken on pypy: https://github.com/ipython/ipyparallel/issues/845)
+if sys.version_info >= (3, 10) and not hasattr(sys, "pypy_version_info"):
     _code_attr_names = tuple(
         _code_attr_map.get(name, name)
         for name, param in inspect.signature(types.CodeType).parameters.items()


### PR DESCRIPTION
The new serialization code for Python 3.10+ does not seem to work on PyPy3.10 7.3.13, as it causes:

    ValueError: no signature found for builtin type <class 'code'>

Switch back to the old code if PyPy is used, at least for the time being.  With this change, the test suite passes on PyPy3.10.

Fixes #845