### PR TITLE
fix utcnow deprecation

### DIFF
--- a/ipyparallel/util.py
+++ b/ipyparallel/util.py
@@ -591,7 +591,7 @@ def compare_datetimes(a, b):
 
 def utcnow():
     """Timezone-aware UTC timestamp"""
-    return datetime.utcnow().replace(tzinfo=utc)
+    return datetime.now(utc)
 
 
 def _v(version_s):


### PR DESCRIPTION
The utcnow deprecation causes a lot of test failures for me, which all go away with this change.