### PR TITLE
store windows base image in gchr

### DIFF
--- a/.github/workflows/windows-ssh-image.yaml
+++ b/.github/workflows/windows-ssh-image.yaml
@@ -1,0 +1,49 @@
+# because it's too unbelievably slow to install ssh server on Windows
+name: Build image for Windows SSH CI
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ipyparallel-windows-ssh
+  TAG: 3.12-2022
+
+jobs:
+  build-and-push-image:
+    runs-on: windows-2022
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      #       - name: Extract metadata (tags, labels) for Docker
+      #         id: meta
+      #         uses: docker/metadata-action@v5
+      #         with:
+      #           labels: |
+      #             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+      #
+      #           images: ${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+      #           tags: |
+      #             type=raw,value=${{ env.TAG }}
+
+      - name: Build image
+        # can't use build-push-action on Windows
+        # https://github.com/docker/build-push-action/issues/18
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.TAG }} -f ci/ssh/win_base_Dockerfile ci/ssh
+      - name: Push image
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}

--- a/ci/ssh/win_base_Dockerfile
+++ b/ci/ssh/win_base_Dockerfile
@@ -1,0 +1,16 @@
+# syntax = docker/dockerfile:1.2.1
+FROM python:3.12-windowsservercore-ltsc2022
+SHELL ["powershell"]
+
+
+RUN Get-WindowsCapability -Online | Where-Object Name -like 'OpenSSH*'; \
+    Write-Host 'Install OpenSSH Server...'; \
+    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0; \
+    Write-Host 'Initializing OpenSSH Server...'; \
+    Start-Service sshd; \
+    Stop-Service sshd
+
+# This is apparently the only way to keep the sshd service running.
+# Running sshd in the foreground in the context of a user (as it is done for linux), doesn't work under Windows.
+# Even if it is started as admin user, errors occur during logon (lack of some system rights)
+CMD powershell -NoExit -Command "Start-Service sshd"


### PR DESCRIPTION
for windows ssh test

installing openssh server takes ~10 minutes, which is a huge pain

this stores a base image with Python and ssh server, should be much quicker to launch tests

basically just a cache of the initial install step