### PR TITLE
detach io thread output from creation cell

### DIFF
--- a/ipyparallel/_async.py
+++ b/ipyparallel/_async.py
@@ -8,6 +8,8 @@ from functools import partial
 
 from tornado.ioloop import IOLoop
 
+from ipyparallel.util import _OutputProducingThread as Thread
+
 
 def _asyncio_run(coro):
     """Like asyncio.run, but works when there's no event loop"""
@@ -41,7 +43,7 @@ class AsyncFirst:
         """Run an async function in a background thread"""
         if self._async_thread is None:
             self._loop_started = threading.Event()
-            self._async_thread = threading.Thread(target=self._thread_main, daemon=True)
+            self._async_thread = Thread(target=self._thread_main, daemon=True)
             self._async_thread.start()
             self._loop_started.wait(timeout=5)
 

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -7,7 +7,6 @@ import json
 import os
 import re
 import socket
-import sys
 import time
 import types
 import warnings
@@ -16,7 +15,7 @@ from concurrent.futures import Future
 from functools import partial
 from getpass import getpass
 from pprint import pprint
-from threading import Event, Thread, current_thread
+from threading import Event, current_thread
 
 import jupyter_client.session
 import zmq
@@ -50,6 +49,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 import ipyparallel as ipp
 from ipyparallel import error, serialize, util
 from ipyparallel.serialize import PrePickled, Reference
+from ipyparallel.util import _OutputProducingThread as Thread
 
 from .asyncresult import AsyncHubResult, AsyncResult
 from .futures import MessageFuture, multi_future
@@ -1079,16 +1079,6 @@ class Client(HasTraits):
         """main loop for background IO thread"""
         self._io_loop = self._make_io_loop()
         self._setup_streams()
-
-        # disable ipykernel's association of thread output with the cell that
-        # spawned the thread.
-        # there should be a public API for this...
-        thread_ident = current_thread().ident
-        for stream in [sys.stdout, sys.stderr]:
-            for name in ("_thread_to_parent", "_thread_to_parent_header"):
-                mapping = getattr(stream, name, None)
-                if mapping:
-                    mapping.pop(thread_ident, None)
         # signal that start has finished
         # so that the main thread knows that all our attributes are defined
         if start_evt:

--- a/ipyparallel/client/client.py
+++ b/ipyparallel/client/client.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import socket
+import sys
 import time
 import types
 import warnings
@@ -1078,6 +1079,16 @@ class Client(HasTraits):
         """main loop for background IO thread"""
         self._io_loop = self._make_io_loop()
         self._setup_streams()
+
+        # disable ipykernel's association of thread output with the cell that
+        # spawned the thread.
+        # there should be a public API for this...
+        thread_ident = current_thread().ident
+        for stream in [sys.stdout, sys.stderr]:
+            for name in ("_thread_to_parent", "_thread_to_parent_header"):
+                mapping = getattr(stream, name, None)
+                if mapping:
+                    mapping.pop(thread_ident, None)
         # signal that start has finished
         # so that the main thread knows that all our attributes are defined
         if start_evt:

--- a/ipyparallel/cluster/launcher.py
+++ b/ipyparallel/cluster/launcher.py
@@ -42,6 +42,7 @@ from traitlets import (
 from traitlets.config.configurable import LoggingConfigurable
 
 from ..traitlets import entry_points
+from ..util import _OutputProducingThread as Thread
 from ..util import shlex_join
 from ._winhpcjob import IPControllerJob, IPControllerTask, IPEngineSetJob, IPEngineTask
 from .shellcmd import ShellCommandSend
@@ -524,7 +525,7 @@ class LocalProcessLauncher(BaseLauncher):
         # ensure self.loop is accessed on the main thread before waiting
         self.loop
         self._stop_waiting = threading.Event()
-        self._wait_thread = threading.Thread(
+        self._wait_thread = Thread(
             target=self._wait, daemon=True, name=f"wait(pid={self.pid})"
         )
         self._wait_thread.start()
@@ -583,7 +584,7 @@ class LocalProcessLauncher(BaseLauncher):
                     time.sleep(0.1)
 
     def _start_streaming(self):
-        self._stream_thread = t = threading.Thread(
+        self._stream_thread = t = Thread(
             target=partial(self._stream_file, self.output_file),
             name=f"Stream Output {self.identifier}",
             daemon=True,
@@ -1352,7 +1353,7 @@ class SSHLauncher(LocalProcessLauncher):
         # ensure self.loop is accessed on the main thread before waiting
         self.loop
         self._stop_waiting = threading.Event()
-        self._wait_thread = threading.Thread(
+        self._wait_thread = Thread(
             target=self._wait,
             daemon=True,
             name=f"wait(host={self.location}, pid={self.pid})",


### PR DESCRIPTION
ipykernel has started associating thread output with the Cell that spawned the Thread (https://github.com/ipython/ipykernel/pull/1186), but that sends output to the _wrong_ cell for cells that are meant to stream to the current output area.

there is currently no opt-out for this, so we have to delete the association after it is created

There should be a public API to disable this for specific Threads, but until then disable the private association after it is created

fixes #893

An alternative (and possibly better?) fix is to explicitly route outputs from the io thread to the main thread, but that's tricky with event loops.