### PR TITLE
Check that MongoDB server is responding

### DIFF
--- a/ipyparallel/tests/test_mongodb.py
+++ b/ipyparallel/tests/test_mongodb.py
@@ -31,7 +31,8 @@ def mongo_conn(request):
         conn_kwargs['port'] = int(os.environ['DB_PORT'])
 
     try:
-        c = MongoClient(**conn_kwargs)
+        c = MongoClient(**conn_kwargs, serverSelectionTimeoutMS = 2000)
+        servinfo = c.server_info()
     except Exception:
         c = None
     if c is not None:

--- a/ipyparallel/tests/test_mongodb.py
+++ b/ipyparallel/tests/test_mongodb.py
@@ -31,7 +31,7 @@ def mongo_conn(request):
         conn_kwargs['port'] = int(os.environ['DB_PORT'])
 
     try:
-        c = MongoClient(**conn_kwargs, serverSelectionTimeoutMS = 2000)
+        c = MongoClient(**conn_kwargs, serverSelectionTimeoutMS=2000)
         servinfo = c.server_info()
     except Exception:
         c = None


### PR DESCRIPTION
If the MongoDB client is installed, but there is no MongoDB server running the MongoDB test fails:
```
==================================== ERRORS ====================================
___________ ERROR at teardown of TestMongoBackend.test_update_record ___________
>   request.addfinalizer(lambda: c.drop_database('iptestdb'))
ipyparallel/tests/test_mongodb.py:38: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib64/python3.13/site-packages/pymongo/_csot.py:105: in csot_wrapper
    return func(self, *args, **kwargs)
/usr/lib64/python3.13/site-packages/pymongo/mongo_client.py:1884: in drop_database
    with self._socket_for_writes(session) as sock_info:
/usr/lib64/python3.13/site-packages/pymongo/mongo_client.py:1239: in _socket_for_writes
    server = self._select_server(writable_server_selector, session)
/usr/lib64/python3.13/site-packages/pymongo/mongo_client.py:1229: in _select_server
    server = topology.select_server(server_selector)
/usr/lib64/python3.13/site-packages/pymongo/topology.py:272: in select_server
    server = self._select_server(selector, server_selection_timeout, address)
/usr/lib64/python3.13/site-packages/pymongo/topology.py:261: in _select_server
    servers = self.select_servers(selector, server_selection_timeout, address)
/usr/lib64/python3.13/site-packages/pymongo/topology.py:223: in select_servers
    server_descriptions = self._select_servers_loop(selector, server_timeout, address)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <Topology <TopologyDescription id: 675036ab775bd5b119588481, topology_type: Unknown, servers: [<ServerDescription ('lo...st', 27017) server_type: Unknown, rtt: None, error=AutoReconnect('localhost:27017: [Errno 111] Connection refused')>]>>
selector = <function writable_server_selector at 0x7f6f2e96f740>, timeout = 30
address = None
    def _select_servers_loop(self, selector, timeout, address):
        """select_servers() guts. Hold the lock when calling this."""
        now = time.monotonic()
        end_time = now + timeout
        server_descriptions = self._description.apply_selector(
            selector, address, custom_selector=self._settings.server_selector
        )
    
        while not server_descriptions:
            # No suitable servers.
            if timeout == 0 or now > end_time:
>               raise ServerSelectionTimeoutError(
                    "%s, Timeout: %ss, Topology Description: %r"
                    % (self._error_message(selector), timeout, self.description)
                )
E               pymongo.errors.ServerSelectionTimeoutError: localhost:27017: [Errno 111] Connection refused, Timeout: 30s, Topology Description: <TopologyDescription id: 675036ab775bd5b119588481, topology_type: Unknown, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None, error=AutoReconnect('localhost:27017: [Errno 111] Connection refused')>]>
/usr/lib64/python3.13/site-packages/pymongo/topology.py:238: ServerSelectionTimeoutError
```
This commit adds a check that the MongoDB server is responding before trying to run the MongoDB tests.