### PR TITLE
Don't fail a test because there are no public IP addresses

### DIFF
--- a/ipyparallel/tests/test_util.py
+++ b/ipyparallel/tests/test_util.py
@@ -8,7 +8,6 @@ from ipyparallel import util
 
 def test_disambiguate_ip():
     # garbage in, garbage out
-    public_ip = public_ips()[0]
     assert util.disambiguate_ip_address('garbage') == 'garbage'
     assert util.disambiguate_ip_address('0.0.0.0', socket.gethostname()) == localhost()
     wontresolve = 'this.wontresolve.dns'
@@ -16,4 +15,6 @@ def test_disambiguate_ip():
         RuntimeWarning, match=f"IPython could not determine IPs for {wontresolve}"
     ):
         assert util.disambiguate_ip_address('0.0.0.0', wontresolve) == wontresolve
-    assert util.disambiguate_ip_address('0.0.0.0', public_ip) == localhost()
+    if public_ips():
+        public_ip = public_ips()[0]
+        assert util.disambiguate_ip_address('0.0.0.0', public_ip) == localhost()


### PR DESCRIPTION
When running the test suite on a machine without public IP addresses configured there is a list index out of range error:
```
=================================== FAILURES ===================================
_____________________________ test_disambiguate_ip _____________________________
    def test_disambiguate_ip():
        # garbage in, garbage out
>       public_ip = public_ips()[0]
E       IndexError: list index out of range
ipyparallel/tests/test_util.py:11: IndexError
```
This commit modifies the test by adding a check that the list is not empty before trying to access its first element.