### PR TITLE
shell_streams -> shell_stream (deprecated since ipykernel 6 (2021))

### DIFF
--- a/ipyparallel/engine/app.py
+++ b/ipyparallel/engine/app.py
@@ -729,7 +729,7 @@ class IPEngine(BaseParallelApplication):
                 control_socket, control_thread.io_loop
             )
 
-            kernel_kwargs["shell_streams"] = [zmqstream.ZMQStream(shell_socket)]
+            kernel_kwargs["shell_stream"] = zmqstream.ZMQStream(shell_socket)
 
             self.kernel = Kernel.instance(
                 parent=self,


### PR DESCRIPTION
Prevent the removal of the shim in ipython/ipykernel#1504