### PR TITLE
fix ShellCommandReceive ImportError

### DIFF
--- a/ipyparallel/shellcmd.py
+++ b/ipyparallel/shellcmd.py
@@ -16,7 +16,7 @@ import os
 import sys
 from argparse import ArgumentParser
 
-from .cluster.shellcmd import ShellCommandReceive
+from .cluster.shellcmd_receive import ShellCommandReceive
 
 
 def main():

--- a/ipyparallel/tests/test_shellcmd.py
+++ b/ipyparallel/tests/test_shellcmd.py
@@ -128,6 +128,12 @@ sender_ids = [
 ]
 
 
+def test_shellcmd_module_import():
+    import ipyparallel.shellcmd
+
+    assert callable(ipyparallel.shellcmd.main)
+
+
 @pytest.fixture
 def shellcmd_test_cmd():
     """returns a command that runs for 5 seconds"""


### PR DESCRIPTION
Fix follow ImportError and add a testcase
```
File "/.../ipyparallel/shellcmd.py", line 19, in <module>
    from .cluster.shellcmd import ShellCommandReceive
ImportError: cannot import name 'ShellCommandReceive' from 'ipyparallel.cluster.shellcmd'
```